### PR TITLE
Library Crate Documentation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,123 @@
+name: Rust Continuous Integration
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:  
+      - "main"
+    paths: 
+      - "**.rs"
+      - "Cargo.lock"
+      - "Cargo.toml"
+env:
+  CARGO_TERM_COLOR: always
+  
+concurrency:
+  group:  CI-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and Initialize Cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions/cache@v3.0.11
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./.cargo/.build
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: build
+    
+  
+  check:
+    name: Check
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions/cache@v3.0.11
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./.cargo/.build
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions/cache@v3.0.11
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./.cargo/.build
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: test
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: actions/cache@v3.0.11
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./.cargo/.build
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions-rs/cargo@v1.0.3
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "create-rust-app"
-version = "8.1.0"
+version = "8.1.1"
 dependencies = [
  "actix-files",
  "actix-http",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "create-rust-app_cli"
-version = "8.1.0"
+version = "8.1.1"
 dependencies = [
  "Inflector",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Temporary(?) fork used by JARA for development because [Wulf/create-rust-app](https://github.com/Wulf/create-rust-app) is sometimes a bit slow to merge PR's
+
 # <img src="https://user-images.githubusercontent.com/4259838/150465966-7ac954d1-9f0c-48d4-a37a-10543b3bbfe1.png" height="40px"> Create Rust App
 
 <a href="https://crates.io/crates/create-rust-app"><img src="https://img.shields.io/crates/v/create-rust-app.svg?style=for-the-badge" height="20" alt="License: MIT OR Apache-2.0" /></a>

--- a/create-rust-app/src/auth/controller.rs
+++ b/create-rust-app/src/auth/controller.rs
@@ -6,10 +6,10 @@ use crate::auth::{
 };
 use crate::{Database, Mailer};
 
-use serde::{Deserialize, Serialize};
 use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
 
-pub const COOKIE_NAME: &'static str = "refresh_token";
+pub const COOKIE_NAME: &str = "refresh_token";
 
 lazy_static! {
     static ref ARGON_CONFIG: argon2::Config<'static> = argon2::Config {
@@ -118,7 +118,7 @@ pub fn get_sessions(
 ) -> Result<UserSessionResponse, (StatusCode, Message)> {
     let mut db = db.pool.get().unwrap();
 
-    let sessions = UserSession::read_all(&mut db, &info, auth.user_id);
+    let sessions = UserSession::read_all(&mut db, info, auth.user_id);
 
     if sessions.is_err() {
         return Err((500, "Could not fetch sessions."));
@@ -237,6 +237,8 @@ pub fn login(
         let device_string = item.device.as_ref().unwrap();
         if device_string.len() > 256 {
             return Err((400, "'device' cannot be longer than 256 characters."));
+        } else {
+            device = Some(device_string.to_owned());
         }
     }
 
@@ -252,7 +254,13 @@ pub fn login(
         return Err((400, "Account has not been activated."));
     }
 
-    let is_valid = argon2::verify_encoded_ext(&user.hash_password, item.password.as_bytes(), &ARGON_CONFIG.secret, &ARGON_CONFIG.ad).unwrap();
+    let is_valid = argon2::verify_encoded_ext(
+        &user.hash_password,
+        item.password.as_bytes(),
+        ARGON_CONFIG.secret,
+        ARGON_CONFIG.ad,
+    )
+    .unwrap();
 
     if !is_valid {
         return Err((401, "Invalid credentials."));
@@ -377,7 +385,7 @@ pub fn refresh(
     let refresh_token_str = refresh_token_str.unwrap();
 
     let refresh_token = decode::<RefreshTokenClaims>(
-        &refresh_token_str,
+        refresh_token_str,
         &DecodingKey::from_secret(std::env::var("SECRET_KEY").unwrap().as_ref()),
         &Validation::default(),
     );
@@ -482,8 +490,7 @@ pub fn register(
 
     let user = User::find_by_email(&mut db, (&item.email).to_string());
 
-    if user.is_ok() {
-        let user = user.unwrap();
+    if let Ok(user) = user {
         if !user.activated {
             User::delete(&mut db, user.id).unwrap();
         } else {
@@ -492,7 +499,7 @@ pub fn register(
     }
 
     let salt = generate_salt();
-    let hash = argon2::hash_encoded(&item.password.as_bytes(), &salt, &ARGON_CONFIG).unwrap();
+    let hash = argon2::hash_encoded(item.password.as_bytes(), &salt, &ARGON_CONFIG).unwrap();
 
     let user = User::create(
         &mut db,
@@ -518,7 +525,7 @@ pub fn register(
     .unwrap();
 
     mail::auth_register::send(
-        &mailer,
+        mailer,
         &user.email,
         &format!(
             "http://localhost:3000/activate?token={token}",
@@ -589,7 +596,7 @@ pub fn activate(
         return Err((500, "Could not activate user."));
     }
 
-    mail::auth_activated::send(&mailer, &user.email);
+    mail::auth_activated::send(mailer, &user.email);
 
     Ok(())
 }
@@ -615,9 +622,7 @@ pub fn forgot_password(
 
     let user_result = User::find_by_email(&mut db, item.email.clone());
 
-    if user_result.is_ok() {
-        let user = user_result.unwrap();
-
+    if let Ok(user) = user_result {
         // if !user.activated {
         //   return Ok(HttpResponse::build(400).body(" has not been activate"))
         // }
@@ -639,10 +644,10 @@ pub fn forgot_password(
             "http://localhost:3000/reset?token={reset_token}",
             reset_token = reset_token
         );
-        mail::auth_recover_existent_account::send(&mailer, &user.email, link);
+        mail::auth_recover_existent_account::send(mailer, &user.email, link);
     } else {
-        let link = &format!("http://localhost:300/register");
-        mail::auth_recover_nonexistent_account::send(&mailer, &item.email, link);
+        let link = &"http://localhost:300/register".to_string();
+        mail::auth_recover_nonexistent_account::send(mailer, &item.email, link);
     }
 
     Ok(())
@@ -662,7 +667,7 @@ pub fn change_password(
     auth: &Auth,
     mailer: &Mailer,
 ) -> Result<(), (StatusCode, Message)> {
-    if item.old_password.len() == 0 || item.new_password.len() == 0 {
+    if item.old_password.is_empty() || item.new_password.is_empty() {
         return Err((400, "Missing password"));
     }
 
@@ -684,14 +689,21 @@ pub fn change_password(
         return Err((400, "Account has not been activated"));
     }
 
-    let is_old_password_valid = argon2::verify_encoded_ext(&user.hash_password, item.old_password.as_bytes(), &ARGON_CONFIG.secret, &ARGON_CONFIG.ad).unwrap();
+    let is_old_password_valid = argon2::verify_encoded_ext(
+        &user.hash_password,
+        item.old_password.as_bytes(),
+        ARGON_CONFIG.secret,
+        ARGON_CONFIG.ad,
+    )
+    .unwrap();
 
     if !is_old_password_valid {
         return Err((400, "Invalid credentials"));
     }
 
     let salt = generate_salt();
-    let new_hash = argon2::hash_encoded(&item.new_password.as_bytes(), &salt, &ARGON_CONFIG).unwrap();
+    let new_hash =
+        argon2::hash_encoded(item.new_password.as_bytes(), &salt, &ARGON_CONFIG).unwrap();
 
     let updated_user = User::update(
         &mut db,
@@ -707,7 +719,7 @@ pub fn change_password(
         return Err((500, "Could not update password"));
     }
 
-    mail::auth_password_changed::send(&mailer, &user.email);
+    mail::auth_password_changed::send(mailer, &user.email);
 
     Ok(())
 }
@@ -733,7 +745,7 @@ pub fn reset_password(
 ) -> Result<(), (StatusCode, Message)> {
     let mut db = db.pool.get().unwrap();
 
-    if item.new_password.len() == 0 {
+    if item.new_password.is_empty() {
         return Err((400, "Missing password"));
     }
 
@@ -766,7 +778,8 @@ pub fn reset_password(
     }
 
     let salt = generate_salt();
-    let new_hash = argon2::hash_encoded(&item.new_password.as_bytes(), &salt, &ARGON_CONFIG).unwrap();
+    let new_hash =
+        argon2::hash_encoded(item.new_password.as_bytes(), &salt, &ARGON_CONFIG).unwrap();
 
     let update = User::update(
         &mut db,
@@ -782,7 +795,7 @@ pub fn reset_password(
         return Err((500, "Could not update password"));
     }
 
-    mail::auth_password_reset::send(&mailer, &user.email);
+    mail::auth_password_reset::send(mailer, &user.email);
 
     Ok(())
 }

--- a/create-rust-app/src/auth/controller.rs
+++ b/create-rust-app/src/auth/controller.rs
@@ -28,6 +28,8 @@ type StatusCode = i32;
 type Message = &'static str;
 
 #[derive(Deserialize, Serialize)]
+/// Rust struct representing the Json body of 
+/// POST requests to the .../login endpoint
 pub struct LoginInput {
     email: String,
     password: String,
@@ -36,6 +38,7 @@ pub struct LoginInput {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+/// TODO: documentation
 pub struct RefreshTokenClaims {
     exp: usize,
     sub: ID,
@@ -43,12 +46,15 @@ pub struct RefreshTokenClaims {
 }
 
 #[derive(Serialize, Deserialize)]
+/// Rust struct representing the Json body of 
+/// POST requests to the .../register endpoint
 pub struct RegisterInput {
     email: String,
     password: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+/// TODO: documentation
 pub struct RegistrationClaims {
     exp: usize,
     sub: ID,
@@ -56,16 +62,21 @@ pub struct RegistrationClaims {
 }
 
 #[derive(Serialize, Deserialize)]
+/// Rust struct representing the Json body of 
+/// GET requests to the .../activate endpoint
 pub struct ActivationInput {
     activation_token: String,
 }
 
 #[derive(Serialize, Deserialize)]
+/// Rust struct representing the Json body of 
+/// POST requests to the /forgot endpoint
 pub struct ForgotInput {
     email: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+/// TODO: documentation
 pub struct ResetTokenClaims {
     exp: usize,
     sub: ID,
@@ -73,18 +84,33 @@ pub struct ResetTokenClaims {
 }
 
 #[derive(Serialize, Deserialize)]
+/// Rust struct representing the Json body of 
+/// POST requests to the /change endpoint
 pub struct ChangeInput {
     old_password: String,
     new_password: String,
 }
 
 #[derive(Serialize, Deserialize)]
+/// Rust struct representing the Json body of 
+/// POST requests to the /reset endpoint
 pub struct ResetInput {
     reset_token: String,
     new_password: String,
 }
 
 /// /sessions
+/// 
+/// queries [`db`](`Database`) for all sessions owned by the User 
+/// associated with [`auth`](`Auth`)
+/// 
+/// breaks up the results of that query as defined by [`info`](`PaginationParams`)
+/// 
+/// 
+/// # Returns [`Result`] 
+/// - Ok([`UserSessionResponse`])
+///     - the results of the query paginated according to [`info`](`PaginationParams`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn get_sessions(
     db: &Database,
     auth: &Auth,
@@ -135,6 +161,13 @@ pub fn get_sessions(
 }
 
 /// /sessions/{id}
+/// 
+/// deletes the entry in the `user_session` with the specified [`item_id`](`ID`) from
+/// [`db`](`Database`) if it's owned by the User associated with [`auth`](`Auth`)
+/// 
+/// # Returns [`Result`] 
+/// - Ok(`()`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn destroy_session(
     db: &Database,
     auth: &Auth,
@@ -162,6 +195,13 @@ pub fn destroy_session(
 }
 
 /// /sessions
+/// 
+/// destroys all entries in the `user_session` table in [`db`](`Database`) owned
+/// by the User associated with [`auth`](`Auth`)
+/// 
+/// # Returns [`Result`] 
+/// - Ok(`()`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn destroy_sessions(db: &Database, auth: &Auth) -> Result<(), (StatusCode, Message)> {
     let mut db = db.pool.get().unwrap();
 
@@ -176,9 +216,15 @@ type AccessToken = String;
 type RefreshToken = String;
 
 /// /login
-/// Returns a tuple;
-/// - the access token should be sent to the user in the body, and,
-/// - the reset token should be sent as a secure, http-only, and same_site=strict cookie.
+/// 
+/// creates a user session for the user associated with [`item`](`LoginInput`) 
+/// in the request body (have the `content-type` header set to `application/json` and content that can be deserialized into [`LoginInput`])
+/// 
+/// # Returns [`Result`]
+/// - Ok([`AccessToken`], [`RefreshToken`]) 
+///     - an access token that should be sent to the user in the response body,
+///     - a reset token that should be sent as a secure, http-only, and same_site=strict cookie.
+/// - Err([`StatusCode`], [`Message`])
 pub fn login(
     db: &Database,
     item: &LoginInput,
@@ -279,6 +325,10 @@ pub fn login(
 
 /// /logout
 /// If this is successful, delete the cookie storing the refresh token
+/// 
+/// # Returns [`Result`] 
+/// - Ok(`()`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn logout(db: &Database, refresh_token: Option<&'_ str>) -> Result<(), (StatusCode, Message)> {
     let mut db = db.pool.get().unwrap();
 
@@ -306,9 +356,14 @@ pub fn logout(db: &Database, refresh_token: Option<&'_ str>) -> Result<(), (Stat
 }
 
 /// /refresh
-/// Returns a tuple;
-/// - the access token should be sent to the user in the body, and,
-/// - the reset token should be sent as a secure, http-only, and same_site=strict cookie.
+/// 
+/// refreshes the user session associated with the clients refresh_token cookie
+/// 
+/// # Returns [`Result`]
+/// - Ok([`AccessToken`], [`RefreshToken`]) 
+///     - an access token that should be sent to the user in the response body,
+///     - a reset token that should be sent as a secure, http-only, and same_site=strict cookie.
+/// - Err([`StatusCode`], [`Message`])
 pub fn refresh(
     db: &Database,
     refresh_token_str: Option<&'_ str>,
@@ -408,6 +463,16 @@ pub fn refresh(
 }
 
 /// /register
+/// 
+/// creates a new User with the information in [`item`](`RegisterInput`)
+/// 
+/// sends an email, using [`mailer`](`Mailer`), to the email address in [`item`](`RegisterInput`)
+/// that contains a unique link that allows the recipient to activate the account associated with
+/// that email address
+/// 
+/// # Returns [`Result`] 
+/// - Ok(`()`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn register(
     db: &Database,
     item: &RegisterInput,
@@ -465,6 +530,12 @@ pub fn register(
 }
 
 /// /activate
+/// 
+/// activates the account associated with the token in [`item`](`ActivationInput`) 
+/// 
+/// # Returns [`Result`] 
+/// - Ok(`()`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn activate(
     db: &Database,
     item: &ActivationInput,
@@ -524,6 +595,17 @@ pub fn activate(
 }
 
 /// /forgot
+/// sends an email to the email in the ['ForgotInput'] Json in the request body
+/// that will allow the user associated with that email to change their password
+/// 
+/// sends an email, using [`mailer`](`Mailer`), to the email address in [`item`](`RegisterInput`)
+/// that contains a unique link that allows the recipient to reset the password 
+/// of the account associated with that email address (or create a new account if there is
+/// no accound accosiated with the email address)
+/// 
+/// # Returns [`Result`] 
+/// - Ok(`()`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn forgot_password(
     db: &Database,
     item: &ForgotInput,
@@ -567,6 +649,13 @@ pub fn forgot_password(
 }
 
 /// /change
+/// 
+/// change the password of the User associated with [`auth`](`Auth`)
+/// from [`item.old_password`](`ChangeInput`) to [`item.new_password`](`ChangeInput`)
+/// 
+/// # Returns [`Result`] 
+/// - Ok(`()`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn change_password(
     db: &Database,
     item: &ChangeInput,
@@ -624,9 +713,19 @@ pub fn change_password(
 }
 
 /// /check
+/// 
+/// just a lifeline function, clients can post to this endpoint to check
+/// if the auth service is running
 pub fn check(_: &Auth) {}
 
 /// reset
+/// 
+/// changes the password of the user associated with [`item.reset_token`](`ResetInput`)
+/// to [`item.new_password`](`ResetInput`)
+/// 
+/// # Returns [`Result`] 
+/// - Ok(`()`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn reset_password(
     db: &Database,
     item: &ResetInput,

--- a/create-rust-app/src/auth/endpoints/service_actixweb.rs
+++ b/create-rust-app/src/auth/endpoints/service_actixweb.rs
@@ -138,7 +138,7 @@ async fn login(db: Data<Database>, Json(item): Json<LoginInput>) -> Result<HttpR
     match result {
         Ok((access_token, refresh_token)) => Ok(HttpResponse::build(StatusCode::OK)
             .cookie(
-                Cookie::build(COOKIE_NAME, refresh_token.clone())
+                Cookie::build(COOKIE_NAME, refresh_token)
                     .secure(true)
                     .http_only(true)
                     .same_site(SameSite::Strict)
@@ -403,7 +403,7 @@ async fn reset_password(
 
 /// returns the endpoints for the Auth service
 pub fn endpoints(scope: actix_web::Scope) -> actix_web::Scope {
-    return scope
+    scope
         .service(sessions)
         .service(destroy_session)
         .service(destroy_sessions)
@@ -415,5 +415,5 @@ pub fn endpoints(scope: actix_web::Scope) -> actix_web::Scope {
         .service(activate)
         .service(forgot_password)
         .service(change_password)
-        .service(reset_password);
+        .service(reset_password)
 }

--- a/create-rust-app/src/auth/endpoints/service_actixweb.rs
+++ b/create-rust-app/src/auth/endpoints/service_actixweb.rs
@@ -19,6 +19,20 @@ use crate::Database;
 use crate::Mailer;
 
 #[get("/sessions")]
+/// handler for GET requests at the .../sessions endpoint,
+/// 
+/// requires auth
+/// 
+/// request should be a query that contains [`PaginationParams`]
+/// 
+/// see [`controller::get_sessions`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | [`UserSessionResponse`](`crate::auth::UserSessionResponse`) deserialized into a Json payload
+/// | 500 | Json payload : {"message": "Could not fetch sessions."}
+/// TODO: document the rest of the possible StatusCodes
 async fn sessions(
     db: Data<Database>,
     auth: Auth,
@@ -38,6 +52,21 @@ async fn sessions(
 }
 
 #[delete("/sessions/{id}")]
+/// handler for DELETE requests at the .../sessions/{id} endpoint.
+/// 
+/// requires auth
+/// 
+/// see [`controller::destroy_session`]
+/// 
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Deleted."}
+/// | 404 | Json payload : {"message": "Session not found."}
+/// | 500 | Json payload : {"message": "Internal error."}
+/// | 500 | Json payload : {"message": "Could not delete session.`}
+/// TODO: document the rest of the possible StatusCodes
 async fn destroy_session(
     db: Data<Database>,
     item_id: Path<ID>,
@@ -58,6 +87,20 @@ async fn destroy_session(
 }
 
 #[delete("/sessions")]
+/// handler for DELETE requests at the .../sessions enpoint
+/// 
+/// requires auth
+/// 
+/// deletes all current sessions belonging to the user
+/// 
+/// see [`controller::destroy_sessions`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Deleted."}
+/// | 500 | Json payload : {"message": "Could not delete sessions."}
+/// TODO: document the rest of the possible StatusCodes
 async fn destroy_sessions(db: Data<Database>, auth: Auth) -> Result<HttpResponse, AWError> {
     let result = web::block(move || controller::destroy_sessions(&db, &auth)).await?;
 
@@ -73,6 +116,22 @@ async fn destroy_sessions(db: Data<Database>, auth: Auth) -> Result<HttpResponse
 }
 
 #[post("/login")]
+/// handler for POST requests at the .../login endpoint
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`LoginInput`]
+/// 
+/// see [`controller::login`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload with an "assess_token" field containing a JWT associated with the user
+/// | 400 | Json payload : {"message": "'device' cannot be longer than 256 characters."}
+/// | 400 | Json payload : {"message": "Account has not been activated."}
+/// | 401 | Json payload : {"message": "Invalid credentials."}
+/// | 500 | Json payload : {"message": "An internal server error occurred."}
+/// | 500 | Json payload : {"message": "Could not create a session."}
+/// TODO: document the rest of the possible StatusCodes
 async fn login(db: Data<Database>, Json(item): Json<LoginInput>) -> Result<HttpResponse, AWError> {
     let result = web::block(move || controller::login(&db, &item)).await?;
 
@@ -94,6 +153,17 @@ async fn login(db: Data<Database>, Json(item): Json<LoginInput>) -> Result<HttpR
 }
 
 #[post("/logout")]
+/// handler for POST requests to the .../logout endpount
+/// 
+/// see [`controller::logout']
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | command to delete the "refresh_token" cookie
+/// | 401 | Json payload : {"message": "Invalid session."}
+/// | 401 | Json payload : {"message": "Could not delete session."}
+/// TODO: document the rest of the possible StatusCodes
 async fn logout(db: Data<Database>, req: HttpRequest) -> Result<HttpResponse, AWError> {
     let refresh_token = req
         .cookie(COOKIE_NAME)
@@ -118,6 +188,17 @@ async fn logout(db: Data<Database>, req: HttpRequest) -> Result<HttpResponse, AW
 }
 
 #[post("/refresh")]
+/// handler for POST requests to the .../refresh endpoint
+/// 
+/// see [`controller::refresh`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload with an "assess_token" field containing a JWT associated with the user
+/// | 401 | Json payload : {"message": "Invalid session."}
+/// | 401 | Json payload : {"message": "Invalid token."}
+/// TODO: document the rest of the possible StatusCodes
 async fn refresh(db: Data<Database>, req: HttpRequest) -> Result<HttpResponse, AWError> {
     let refresh_token = req
         .cookie(COOKIE_NAME)
@@ -145,6 +226,18 @@ async fn refresh(db: Data<Database>, req: HttpRequest) -> Result<HttpResponse, A
 }
 
 #[post("/register")]
+/// handler for POST requests to the .../register endpoint
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`RegisterInput`]
+/// 
+/// see [`controller::register`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Registered! Check your email to activate your account."}
+/// | 400 | Json payload : {"message": "Already registered."}
+/// TODO: document the rest of the possible StatusCodes
 async fn register(
     db: Data<Database>,
     Json(item): Json<RegisterInput>,
@@ -163,6 +256,19 @@ async fn register(
 }
 
 #[get("/activate")]
+/// handler for GET requests to the .../activate endpoint
+/// 
+/// see [`controller:: activate`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Activated."}
+/// | 200 | Json payload : {"message": "Already activated."}
+/// | 400 | Json payload : {"message": "Invalid token."}
+/// | 401 | Json payload : {"message": "Invalid token"}
+/// | 500 | Json payload : {"message": "Could not activate user. "}
+/// TODO: document the rest of the possible StatusCodes
 async fn activate(
     db: Data<Database>,
     Query(item): Query<ActivationInput>,
@@ -180,6 +286,17 @@ async fn activate(
 }
 
 #[post("/forgot")]
+/// handler for POST requests to the .../forgot endpoint
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ForgotInput`]
+/// 
+/// see [`controller::forgot_password`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Please check your email."}
+/// TODO: document the rest of the possible StatusCodes
 async fn forgot_password(
     db: Data<Database>,
     Json(item): Json<ForgotInput>,
@@ -198,6 +315,25 @@ async fn forgot_password(
 }
 
 #[post("/change")]
+/// handler for POST requests to the .../change endpoint
+/// 
+/// requires auth
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ChangeInput`]
+/// 
+/// see [`controller::change_password`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Password changed."}
+/// | 400 | Json payload : {"message": "Missing password."}
+/// | 400 | Json payload : {"message": "The new password must be different."}
+/// | 400 | Json payload : {"message": "Account has not been activated."}
+/// | 400 | Json payload : {"message": "Invalid credentials."}
+/// | 500 | Json payload : {"message": "Could not find user."}
+/// | 500 | Json payload : {"message": "Could not update password."}
+/// TODO: document the rest of the possible StatusCodes
 async fn change_password(
     db: Data<Database>,
     Json(item): Json<ChangeInput>,
@@ -217,12 +353,37 @@ async fn change_password(
 }
 
 #[post("/check")]
+/// handler for POST requests to the .../check endpoint
+/// 
+/// requires auth, but doesn't match it to a user
+/// 
+/// see [`controller::check`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | ()
 async fn check(auth: Auth) -> HttpResponse {
     controller::check(&auth);
     HttpResponse::Ok().finish()
 }
 
 #[post("/reset")]
+/// handler for POST requests to the .../reset endpoint
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ResetInput`]
+/// 
+/// see [`controller::reset_password`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Password changed."}
+/// | 400 | Json payload : {"message": "Invalid token."}
+/// | 400 | Json payload : {"message": "Account has not been activated."}
+/// | 400 | Json payload : {"message": "The new password must be different."}
+/// | 401 | Json payload : {"message": "Invalid token."}
+/// | 500 | Json payload : {"message": "Could not update password."}
 async fn reset_password(
     db: Data<Database>,
     Json(item): Json<ResetInput>,
@@ -240,6 +401,7 @@ async fn reset_password(
     }
 }
 
+/// returns the endpoints for the Auth service
 pub fn endpoints(scope: actix_web::Scope) -> actix_web::Scope {
     return scope
         .service(sessions)

--- a/create-rust-app/src/auth/endpoints/service_poem.rs
+++ b/create-rust-app/src/auth/endpoints/service_poem.rs
@@ -24,6 +24,20 @@ fn error_response(status_code: i32, message: &'static str) -> Error {
 }
 
 #[handler]
+/// handler for GET requests at the .../sessions endpoint,
+/// 
+/// requires auth
+/// 
+/// request should be a query that contains [`PaginationParams`]
+/// 
+/// see [`controller::get_sessions`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | [`UserSessionResponse`](`crate::auth::UserSessionResponse`) deserialized into a Json payload
+/// | 500 | Json payload : {"message": "Could not fetch sessions."}
+/// TODO: document the rest of the possible StatusCodes
 async fn sessions(
     db: Data<&Database>,
     auth: Auth,
@@ -38,6 +52,20 @@ async fn sessions(
 }
 
 #[handler]
+/// handler for DELETE requests at the .../sessions enpoint
+/// 
+/// requires auth
+/// 
+/// deletes all current sessions belonging to the user
+/// 
+/// see [`controller::destroy_sessions`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Deleted."}
+/// | 500 | Json payload : {"message": "Could not delete sessions."}
+/// TODO: document the rest of the possible StatusCodes
 async fn destroy_sessions(db: Data<&Database>, auth: Auth) -> Result<impl IntoResponse> {
     let result = controller::destroy_sessions(db.0, &auth);
 
@@ -48,6 +76,21 @@ async fn destroy_sessions(db: Data<&Database>, auth: Auth) -> Result<impl IntoRe
 }
 
 #[handler]
+/// handler for DELETE requests at the .../sessions/{id} endpoint.
+/// 
+/// requires auth
+/// 
+/// see [`controller::destroy_session`]
+/// 
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Deleted."}
+/// | 404 | Json payload : {"message": "Session not found."}
+/// | 500 | Json payload : {"message": "Internal error."}
+/// | 500 | Json payload : {"message": "Could not delete session.`}
+/// TODO: document the rest of the possible StatusCodes
 async fn destroy_session(
     db: Data<&Database>,
     Path(item_id): Path<ID>,
@@ -62,6 +105,22 @@ async fn destroy_session(
 }
 
 #[handler]
+/// handler for POST requests at the .../login endpoint
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`LoginInput`]
+/// 
+/// see [`controller::login`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload with an "assess_token" field containing a JWT associated with the user
+/// | 400 | Json payload : {"message": "'device' cannot be longer than 256 characters."}
+/// | 400 | Json payload : {"message": "Account has not been activated."}
+/// | 401 | Json payload : {"message": "Invalid credentials."}
+/// | 500 | Json payload : {"message": "An internal server error occurred."}
+/// | 500 | Json payload : {"message": "Could not create a session."}
+/// TODO: document the rest of the possible StatusCodes
 async fn login(
     db: Data<&Database>,
     Json(item): Json<LoginInput>,
@@ -87,6 +146,17 @@ async fn login(
 }
 
 #[handler]
+/// handler for POST requests to the .../logout endpount
+/// 
+/// see [`controller::logout']
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | command to delete the "refresh_token" cookie
+/// | 401 | Json payload : {"message": "Invalid session."}
+/// | 401 | Json payload : {"message": "Could not delete session."}
+/// TODO: document the rest of the possible StatusCodes
 async fn logout(db: Data<&Database>, cookie_jar: &CookieJar) -> Result<impl IntoResponse> {
     let refresh_token = cookie_jar
         .get(COOKIE_NAME)
@@ -108,6 +178,17 @@ async fn logout(db: Data<&Database>, cookie_jar: &CookieJar) -> Result<impl Into
 }
 
 #[handler]
+/// handler for POST requests to the .../refresh endpoint
+/// 
+/// see [`controller::refresh`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload with an "assess_token" field containing a JWT associated with the user
+/// | 401 | Json payload : {"message": "Invalid session."}
+/// | 401 | Json payload : {"message": "Invalid token."}
+/// TODO: document the rest of the possible StatusCodes
 async fn refresh(db: Data<&Database>, cookie_jar: &CookieJar) -> Result<impl IntoResponse> {
     let refresh_token = cookie_jar
         .get(COOKIE_NAME)
@@ -132,6 +213,18 @@ async fn refresh(db: Data<&Database>, cookie_jar: &CookieJar) -> Result<impl Int
 }
 
 #[handler]
+/// handler for POST requests to the .../register endpoint
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`RegisterInput`]
+/// 
+/// see [`controller::register`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Registered! Check your email to activate your account."}
+/// | 400 | Json payload : {"message": "Already registered."}
+/// TODO: document the rest of the possible StatusCodes
 async fn register(
     db: Data<&Database>,
     Json(item): Json<RegisterInput>,
@@ -148,6 +241,19 @@ async fn register(
 }
 
 #[handler]
+/// handler for GET requests to the .../activate endpoint
+/// 
+/// see [`controller:: activate`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Activated."}
+/// | 200 | Json payload : {"message": "Already activated."}
+/// | 400 | Json payload : {"message": "Invalid token."}
+/// | 401 | Json payload : {"message": "Invalid token"}
+/// | 500 | Json payload : {"message": "Could not activate user. "}
+/// TODO: document the rest of the possible StatusCodes
 async fn activate(
     db: Data<&Database>,
     Query(item): Query<ActivationInput>,
@@ -165,6 +271,17 @@ async fn activate(
 }
 
 #[handler]
+/// handler for POST requests to the .../forgot endpoint
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ForgotInput`]
+/// 
+/// see [`controller::forgot_password`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Please check your email."}
+/// TODO: document the rest of the possible StatusCodes
 async fn forgot_password(
     db: Data<&Database>,
     Json(item): Json<ForgotInput>,
@@ -181,6 +298,25 @@ async fn forgot_password(
 }
 
 #[handler]
+/// handler for POST requests to the .../change endpoint
+/// 
+/// requires auth
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ChangeInput`]
+/// 
+/// see [`controller::change_password`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Password changed."}
+/// | 400 | Json payload : {"message": "Missing password."}
+/// | 400 | Json payload : {"message": "The new password must be different."}
+/// | 400 | Json payload : {"message": "Account has not been activated."}
+/// | 400 | Json payload : {"message": "Invalid credentials."}
+/// | 500 | Json payload : {"message": "Could not find user."}
+/// | 500 | Json payload : {"message": "Could not update password."}
+/// TODO: document the rest of the possible StatusCodes
 async fn change_password(
     db: Data<&Database>,
     Json(item): Json<ChangeInput>,
@@ -198,6 +334,21 @@ async fn change_password(
 }
 
 #[handler]
+/// handler for POST requests to the .../reset endpoint
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ResetInput`]
+/// 
+/// see [`controller::reset_password`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Password changed."}
+/// | 400 | Json payload : {"message": "Invalid token."}
+/// | 400 | Json payload : {"message": "Account has not been activated."}
+/// | 400 | Json payload : {"message": "The new password must be different."}
+/// | 401 | Json payload : {"message": "Invalid token."}
+/// | 500 | Json payload : {"message": "Could not update password."}
 async fn reset_password(
     db: Data<&Database>,
     Json(item): Json<ResetInput>,
@@ -214,11 +365,22 @@ async fn reset_password(
 }
 
 #[handler]
+/// handler for POST requests to the .../check endpoint
+/// 
+/// requires auth, but doesn't match it to a user
+/// 
+/// see [`controller::check`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | ()
 async fn check(auth: Auth) -> Result<impl IntoResponse> {
     controller::check(&auth);
     Ok(Response::builder().status(StatusCode::OK).finish())
 }
 
+/// returns endpoints for the Auth service
 pub fn api() -> Route {
     Route::new()
         .at("/sessions", get(sessions).delete(destroy_sessions))

--- a/create-rust-app/src/auth/extractors/auth_actixweb.rs
+++ b/create-rust-app/src/auth/extractors/auth_actixweb.rs
@@ -27,7 +27,7 @@ impl Auth {
     /// does the user with the id [`self.user_id`](`ID`) have the given `permission`
     pub fn has_permission(&self, permission: String) -> bool {
         self.permissions.contains(&Permission {
-            permission: permission.to_string(),
+            permission,
             from_role: String::new(),
         })
     }
@@ -43,8 +43,8 @@ impl Auth {
     }
 
     /// does the user with the id [`self.user_id`](`ID`) have the given `role`
-    pub fn has_role(&self, role: String) -> bool {
-        self.roles.contains(&role.to_string())
+    pub fn has_role(&self, permission: String) -> bool {
+        self.roles.contains(&permission)
     }
 
     /// does the user with the id [`self.user_id`](`ID`) have all of the given `roles`
@@ -129,10 +129,10 @@ impl FromRequest for Auth {
             HashSet::from_iter(access_token.claims.permissions.iter().cloned());
         let roles: HashSet<String> = HashSet::from_iter(access_token.claims.roles.iter().cloned());
 
-        return ready(Ok(Auth {
+        ready(Ok(Auth {
             user_id,
             roles,
             permissions,
-        }));
+        }))
     }
 }

--- a/create-rust-app/src/auth/extractors/auth_actixweb.rs
+++ b/create-rust-app/src/auth/extractors/auth_actixweb.rs
@@ -43,8 +43,8 @@ impl Auth {
     }
 
     /// does the user with the id [`self.user_id`](`ID`) have the given `role`
-    pub fn has_role(&self, permission: String) -> bool {
-        self.roles.contains(&permission.to_string())
+    pub fn has_role(&self, role: String) -> bool {
+        self.roles.contains(&role.to_string())
     }
 
     /// does the user with the id [`self.user_id`](`ID`) have all of the given `roles`
@@ -70,7 +70,7 @@ impl ResponseError for AuthError {
     fn error_response(&self) -> HttpResponse {
         // HttpResponse::Unauthorized().json(self.reason.as_str())
         // println!("error_response");
-        HttpResponse::build(StatusCode::UNAUTHORIZED).body(
+        HttpResponse::build(self.status_code()).body(
             json!({
               "message": self.reason.as_str()
             })

--- a/create-rust-app/src/auth/extractors/auth_actixweb.rs
+++ b/create-rust-app/src/auth/extractors/auth_actixweb.rs
@@ -14,6 +14,9 @@ use std::collections::HashSet;
 use std::iter::FromIterator;
 
 #[derive(Debug, Clone)]
+/// roles and permissions available to a User
+/// 
+/// use to control what users are and are not allowed to do
 pub struct Auth {
     pub user_id: ID,
     pub roles: HashSet<String>,
@@ -21,6 +24,7 @@ pub struct Auth {
 }
 
 impl Auth {
+    /// does the user with the id [`self.user_id`](`ID`) have the given `permission`
     pub fn has_permission(&self, permission: String) -> bool {
         self.permissions.contains(&Permission {
             permission: permission.to_string(),
@@ -28,22 +32,27 @@ impl Auth {
         })
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have all of the given `perms`
     pub fn has_all_permissions(&self, perms: Vec<String>) -> bool {
         perms.iter().all(|p| self.has_permission(p.to_string()))
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have any of the given `perms`
     pub fn has_any_permission(&self, perms: Vec<String>) -> bool {
         perms.iter().any(|p| self.has_permission(p.to_string()))
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have the given `role`
     pub fn has_role(&self, permission: String) -> bool {
         self.roles.contains(&permission.to_string())
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have all of the given `roles`
     pub fn has_all_roles(&self, roles: Vec<String>) -> bool {
         roles.iter().all(|r| self.has_role(r.to_string()))
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have any of the given `roles`
     pub fn has_any_roles(&self, roles: Vec<String>) -> bool {
         roles.iter().any(|r| self.has_role(r.to_string()))
     }
@@ -51,11 +60,13 @@ impl Auth {
 
 #[derive(Debug, Display, Error)]
 #[display(fmt = "Unauthorized, reason: {}", self.reason)]
+/// custom error type for Authorization related errors
 pub struct AuthError {
     reason: String,
 }
 
 impl ResponseError for AuthError {
+    /// builds an [`HttpResponse`] for [`self`](`AuthError`)
     fn error_response(&self) -> HttpResponse {
         // HttpResponse::Unauthorized().json(self.reason.as_str())
         // println!("error_response");
@@ -67,6 +78,7 @@ impl ResponseError for AuthError {
         )
     }
 
+    /// return the [`StatusCode`] associated with an [`AuthError`]
     fn status_code(&self) -> StatusCode {
         StatusCode::UNAUTHORIZED
     }
@@ -76,6 +88,7 @@ impl FromRequest for Auth {
     type Future = Ready<Result<Self, Self::Error>>;
     type Error = AuthError;
 
+    /// extracts [`Auth`] from the given [`req`](`HttpRequest`)
     fn from_request(req: &HttpRequest, _payload: &mut Payload) -> <Self as FromRequest>::Future {
         let auth_header_opt: Option<&HeaderValue> = req.headers().get("Authorization");
 

--- a/create-rust-app/src/auth/extractors/auth_poem.rs
+++ b/create-rust-app/src/auth/extractors/auth_poem.rs
@@ -40,8 +40,8 @@ impl Auth {
     }
 
     /// does the user with the id [`self.user_id`](`ID`) have the given `role`
-    pub fn has_role(&self, permission: String) -> bool {
-        self.roles.contains(&permission.to_string())
+    pub fn has_role(&self, role: String) -> bool {
+        self.roles.contains(&role.to_string())
     }
 
     /// does the user with the id [`self.user_id`](`ID`) have all of the given `roles`

--- a/create-rust-app/src/auth/extractors/auth_poem.rs
+++ b/create-rust-app/src/auth/extractors/auth_poem.rs
@@ -11,6 +11,9 @@ use jsonwebtoken::Validation;
 use std::iter::FromIterator;
 
 #[derive(Debug, Clone)]
+/// roles and permissions available to a User
+/// 
+/// use to control what users are and are not allowed to do
 pub struct Auth {
     pub user_id: ID,
     pub roles: HashSet<String>,
@@ -18,6 +21,7 @@ pub struct Auth {
 }
 
 impl Auth {
+    /// does the user with the id [`self.user_id`](`ID`) have the given `permission`
     pub fn has_permission(&self, permission: String) -> bool {
         self.permissions.contains(&Permission {
             permission: permission.to_string(),
@@ -25,22 +29,27 @@ impl Auth {
         })
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have all of the given `perms`
     pub fn has_all_permissions(&self, perms: Vec<String>) -> bool {
         perms.iter().all(|p| self.has_permission(p.to_string()))
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have any of the given `perms`
     pub fn has_any_permissions(&self, perms: Vec<String>) -> bool {
         perms.iter().any(|p| self.has_permission(p.to_string()))
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have the given `role`
     pub fn has_role(&self, permission: String) -> bool {
         self.roles.contains(&permission.to_string())
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have all of the given `roles`
     pub fn has_all_roles(&self, roles: Vec<String>) -> bool {
         roles.iter().all(|r| self.has_role(r.to_string()))
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have any of the given `roles`
     pub fn has_any_roles(&self, roles: Vec<String>) -> bool {
         roles.iter().any(|r| self.has_role(r.to_string()))
     }
@@ -48,6 +57,7 @@ impl Auth {
 
 #[async_trait]
 impl<'a> FromRequest<'a> for Auth {
+    /// extracts [`Auth`] from the given [`req`](`Request`)
     async fn from_request(req: &'a Request, _: &mut RequestBody) -> Result<Self> {
         let auth_header_opt: Option<&HeaderValue> = req.headers().get("Authorization");
 

--- a/create-rust-app/src/auth/mail/auth_activated.rs
+++ b/create-rust-app/src/auth/mail/auth_activated.rs
@@ -3,24 +3,22 @@ use crate::Mailer;
 #[allow(dead_code)]
 pub fn send(mailer: &Mailer, to_email: &str) {
     let subject = "Account activated)";
-    let text = format!(
-        r#"
+    let text = r#"
 (This is an automated message.)
 
 Hello,
 
 Your account has been activated!
 "#
-    );
-    let html = format!(
-        r#"
+    .to_string();
+    let html = r#"
 (This is an automated message.)
 
 Hello,
 
 Your account has been activated!
 "#
-    );
+    .to_string();
 
-    mailer.send(to_email, &subject, &text, &html);
+    mailer.send(to_email, subject, &text, &html);
 }

--- a/create-rust-app/src/auth/mail/auth_password_changed.rs
+++ b/create-rust-app/src/auth/mail/auth_password_changed.rs
@@ -3,24 +3,22 @@ use crate::Mailer;
 #[allow(dead_code)]
 pub fn send(mailer: &Mailer, to_email: &str) {
     let subject = "Your password was changed)";
-    let text = format!(
-        r#"
+    let text = r#"
 (This is an automated message.)
 
 Hello,
 
 Your password was changed successfully!
 "#
-    );
-    let html = format!(
-        r#"
+    .to_string();
+    let html = r#"
 (This is an automated message.)
 
 Hello,
 
 Your password was changed successfully!
 "#
-    );
+    .to_string();
 
-    mailer.send(to_email, &subject, &text, &html);
+    mailer.send(to_email, subject, &text, &html);
 }

--- a/create-rust-app/src/auth/mail/auth_password_reset.rs
+++ b/create-rust-app/src/auth/mail/auth_password_reset.rs
@@ -3,24 +3,23 @@ use crate::Mailer;
 #[allow(dead_code)]
 pub fn send(mailer: &Mailer, to_email: &str) {
     let subject = "Your password was reset)";
-    let text = format!(
-        r#"
+    let text = r#"
 (This is an automated message.)
 
 Hello,
 
 Your password was successfully reset!
 "#
-    );
-    let html = format!(
-        r#"
+    .to_string();
+
+    let html = r#"
 (This is an automated message.)
 
 Hello,
 
 Your password was successfully reset!
 "#
-    );
+    .to_string();
 
-    mailer.send(to_email, &subject, &text, &html);
+    mailer.send(to_email, subject, &text, &html);
 }

--- a/create-rust-app/src/auth/mail/auth_recover_existent_account.rs
+++ b/create-rust-app/src/auth/mail/auth_recover_existent_account.rs
@@ -30,5 +30,5 @@ Please visit this link to reset your password:
         link = link
     );
 
-    mailer.send(to_email, &subject, &text, &html);
+    mailer.send(to_email, subject, &text, &html);
 }

--- a/create-rust-app/src/auth/mail/auth_recover_nonexistent_account.rs
+++ b/create-rust-app/src/auth/mail/auth_recover_nonexistent_account.rs
@@ -28,5 +28,5 @@ If this was intentional, you can register for a new account using the link below
         link = link
     );
 
-    mailer.send(to_email, &subject, &text, &html);
+    mailer.send(to_email, subject, &text, &html);
 }

--- a/create-rust-app/src/auth/mail/auth_register.rs
+++ b/create-rust-app/src/auth/mail/auth_register.rs
@@ -26,5 +26,5 @@ Please follow the link below to complete your registration:
         link = link
     );
 
-    mailer.send(to_email, &subject, &text, &html);
+    mailer.send(to_email, subject, &text, &html);
 }

--- a/create-rust-app/src/auth/mod.rs
+++ b/create-rust-app/src/auth/mod.rs
@@ -33,6 +33,13 @@ type UTC = chrono::NaiveDateTime;
 
 #[tsync::tsync]
 #[derive(Deserialize)]
+/// Rust struct that provides the information needed to allow 
+/// pagination of results for requests that have a lot of results
+/// 
+/// often times, GET requests to a REST API will have a lot of 
+/// results to return, pagination allows the server to break up
+/// those results into smaller chunks that can be more easily 
+/// sent to, and used by, the client
 pub struct PaginationParams {
     pub page: i64,
     pub page_size: i64,
@@ -44,6 +51,8 @@ impl PaginationParams {
 
 #[tsync::tsync]
 #[derive(Debug, Serialize, Deserialize, Clone)]
+/// Rust struct representation of a entry from the databases user_session table 
+/// serialized into Json
 pub struct UserSessionJson {
     pub id: ID,
     pub device: Option<String>,
@@ -54,6 +63,8 @@ pub struct UserSessionJson {
 
 #[tsync::tsync]
 #[derive(Debug, Serialize, Deserialize, Clone)]
+/// Rust struct representation of the 
+/// backends JSON response to a GET request at the /sessions endpoint
 pub struct UserSessionResponse {
     pub sessions: Vec<UserSessionJson>,
     pub num_pages: i64,
@@ -61,6 +72,7 @@ pub struct UserSessionResponse {
 
 #[tsync::tsync]
 #[derive(Debug, Serialize, Deserialize)]
+/// TODO: documentation
 pub struct AccessTokenClaims {
     pub exp: usize,
     pub sub: ID,

--- a/create-rust-app/src/auth/mod.rs
+++ b/create-rust-app/src/auth/mod.rs
@@ -27,9 +27,9 @@ type ID = i32;
 
 #[tsync::tsync]
 #[cfg(not(feature = "database_sqlite"))]
-type UTC = chrono::DateTime<chrono::Utc>;
+type Utc = chrono::DateTime<chrono::Utc>;
 #[cfg(feature = "database_sqlite")]
-type UTC = chrono::NaiveDateTime;
+type Utc = chrono::NaiveDateTime;
 
 #[tsync::tsync]
 #[derive(Deserialize)]
@@ -56,9 +56,9 @@ impl PaginationParams {
 pub struct UserSessionJson {
     pub id: ID,
     pub device: Option<String>,
-    pub created_at: UTC,
+    pub created_at: Utc,
     #[cfg(not(feature = "database_sqlite"))]
-    pub updated_at: UTC,
+    pub updated_at: Utc,
 }
 
 #[tsync::tsync]

--- a/create-rust-app/src/auth/permissions/mod.rs
+++ b/create-rust-app/src/auth/permissions/mod.rs
@@ -34,7 +34,7 @@ impl Role {
         let assigned = UserRole::create(
             db,
             &UserRoleChangeset {
-                user_id: user_id,
+                user_id,
                 role: role.to_string(),
             },
         );
@@ -50,10 +50,7 @@ impl Role {
             db,
             roles
                 .into_iter()
-                .map(|r| UserRoleChangeset {
-                    user_id: user_id,
-                    role: r,
-                })
+                .map(|r| UserRoleChangeset { user_id, role: r })
                 .collect::<Vec<_>>(),
         );
 
@@ -212,7 +209,7 @@ impl Permission {
     /// 
     /// returns true if successful
     pub fn revoke_from_role(db: &mut Connection, role: String, permission: String) -> Result<bool> {
-        let deleted = RolePermission::delete(db, role, permission.to_string());
+        let deleted = RolePermission::delete(db, role, permission);
 
         Ok(deleted.is_ok())
     }

--- a/create-rust-app/src/auth/permissions/mod.rs
+++ b/create-rust-app/src/auth/permissions/mod.rs
@@ -27,6 +27,9 @@ struct RoleQueryRow {
 }
 
 impl Role {
+    /// assign `role` to the User whose id is [`user_id`](`ID`)
+    /// 
+    /// Returns true if successful
     pub fn assign(db: &mut Connection, user_id: ID, role: &str) -> Result<bool> {
         let assigned = UserRole::create(
             db,
@@ -39,6 +42,9 @@ impl Role {
         Ok(assigned.is_ok())
     }
 
+    /// assigns every role in `roles` to the User whose id is [`user_id`](`ID`)
+    /// 
+    /// returns true if successful
     pub fn assign_many(db: &mut Connection, user_id: ID, roles: Vec<String>) -> Result<bool> {
         let assigned = UserRole::create_many(
             db,
@@ -54,18 +60,25 @@ impl Role {
         Ok(assigned.is_ok())
     }
 
+    /// unassigns `role` from the User whose id is [`user_id`](`ID`)
+    /// 
+    /// returns true if successful
     pub fn unassign(db: &mut Connection, user_id: ID, role: &str) -> Result<bool> {
         let unassigned = UserRole::delete(db, user_id, role.to_string());
 
         Ok(unassigned.is_ok())
     }
 
+    /// unassigns every role in `roles` from the User whose id is [`user_id`](`ID`)
+    /// 
+    /// returns true if successful
     pub fn unassign_many(db: &mut Connection, user_id: ID, roles: Vec<String>) -> Result<bool> {
         let unassigned = UserRole::delete_many(db, user_id, roles);
 
         Ok(unassigned.is_ok())
     }
 
+    /// returns a vector containing every role assigned to the User whose id is [`user_id`](`ID`)
     pub fn fetch_all(db: &mut Connection, user_id: ID) -> Result<Vec<String>> {
         let roles = sql_query("SELECT role FROM user_roles WHERE user_id = $1");
 
@@ -83,9 +96,11 @@ impl Role {
 #[derive(Debug, Serialize, Deserialize, QueryableByName, Clone)]
 pub struct Permission {
     #[diesel(sql_type=Text)]
+    /// the role this permission is coming from
     pub from_role: String,
 
     #[diesel(sql_type=Text)]
+    /// the permission itself
     pub permission: String,
 }
 
@@ -110,6 +125,9 @@ impl Permission {
     //   Ok(user_has_permission)
     // }
 
+    /// grants `permission` to the User whose id is [`user_id`](`ID`)
+    /// 
+    /// returns true if successful
     pub fn grant_to_user(db: &mut Connection, user_id: ID, permission: &str) -> Result<bool> {
         let granted = UserPermission::create(
             db,
@@ -122,6 +140,9 @@ impl Permission {
         Ok(granted.is_ok())
     }
 
+    /// grant `permission` to `role`
+    /// 
+    /// returns true if successful
     pub fn grant_to_role(db: &mut Connection, role: &str, permission: &str) -> Result<bool> {
         let granted = RolePermission::create(
             db,
@@ -134,6 +155,9 @@ impl Permission {
         Ok(granted.is_ok())
     }
 
+    /// grants every permission in `permissions` to `role`
+    /// 
+    /// returns true if successful
     pub fn grant_many_to_role(
         db: &mut Connection,
         role: String,
@@ -153,6 +177,9 @@ impl Permission {
         Ok(granted.is_ok())
     }
 
+    /// grants every permission in `permissions` to `role`
+    /// 
+    /// returns true if successful
     pub fn grant_many_to_user(
         db: &mut Connection,
         user_id: i32,
@@ -172,18 +199,27 @@ impl Permission {
         Ok(granted.is_ok())
     }
 
+    /// revokes `permission` from the User whose id is [`user_id`](`ID`)
+    /// 
+    /// returns true if successful
     pub fn revoke_from_user(db: &mut Connection, user_id: ID, permission: &str) -> Result<bool> {
         let deleted = UserPermission::delete(db, user_id, permission.to_string());
 
         Ok(deleted.is_ok())
     }
 
+    /// revokes `permission` from `role`
+    /// 
+    /// returns true if successful
     pub fn revoke_from_role(db: &mut Connection, role: String, permission: String) -> Result<bool> {
         let deleted = RolePermission::delete(db, role, permission.to_string());
 
         Ok(deleted.is_ok())
     }
 
+    /// revokes every permission in `permissions` from the User whose id is [`user_id`](`ID`)
+    /// 
+    /// returns true if successful
     pub fn revoke_many_from_user(
         db: &mut Connection,
         user_id: ID,
@@ -194,6 +230,9 @@ impl Permission {
         Ok(deleted.is_ok())
     }
 
+    /// revokes every permission in `permissions` from `role`
+    /// 
+    /// returns true if successful
     pub fn revoke_many_from_role(
         db: &mut Connection,
         role: String,
@@ -204,18 +243,25 @@ impl Permission {
         Ok(deleted.is_ok())
     }
 
+    /// revokes every permission granted to `role`
+    /// 
+    /// returns true if successful
     pub fn revoke_all_from_role(db: &mut Connection, role: &str) -> Result<bool> {
         let deleted = RolePermission::delete_all(db, role);
 
         Ok(deleted.is_ok())
     }
 
+    /// revokes every permission granted to the User whose id is [`user_id`](`ID`)
+    /// 
+    /// returns true if successful
     pub fn revoke_all_from_user(db: &mut Connection, user_id: i32) -> Result<bool> {
         let deleted = UserPermission::delete_all(db, user_id);
 
         Ok(deleted.is_ok())
     }
 
+    /// returns every permission granted to the User whose id is [`user_id`](`ID`)
     pub fn fetch_all(db: &mut Connection, user_id: ID) -> Result<Vec<Permission>> {
         let permissions = sql_query(
             r#"

--- a/create-rust-app/src/auth/permissions/role_permission.rs
+++ b/create-rust-app/src/auth/permissions/role_permission.rs
@@ -7,6 +7,7 @@ use crate::diesel::*;
 #[tsync::tsync]
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
 #[diesel(table_name = role_permissions)]
+/// Rust struct modeling an entry in the role_permissions table
 pub struct RolePermission {
     /* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     Add columns here in the same order as the schema
@@ -18,6 +19,7 @@ pub struct RolePermission {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Insertable, AsChangeset)]
 #[diesel(table_name = role_permissions)]
+/// Rust struct modeling mutable data in an entry in the role_permissions table
 pub struct RolePermissionChangeset {
     /* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     Add columns here in the same order as the schema
@@ -28,7 +30,9 @@ pub struct RolePermissionChangeset {
     pub permission: String,
 }
 
+/// CRUD functions for [`RolePermission`]
 impl RolePermission {
+    /// Create an entry in the database's role_permissions table that has the data stored in [`item`](`RolePermissionChangeset`)
     pub fn create(db: &mut Connection, item: &RolePermissionChangeset) -> QueryResult<Self> {
         use crate::auth::schema::role_permissions::dsl::*;
 
@@ -38,6 +42,7 @@ impl RolePermission {
     }
 
     #[cfg(feature = "database_sqlite")]
+    /// Create an entry in the database's role_permissions table for each [element](`RolePermissionChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,
         items: Vec<RolePermissionChangeset>,
@@ -50,6 +55,7 @@ impl RolePermission {
     }
 
     #[cfg(not(feature = "database_sqlite"))]
+    /// Create an entry in the database's role_permissions table for each [element](`RolePermissionChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,
         items: Vec<RolePermissionChangeset>,
@@ -61,6 +67,8 @@ impl RolePermission {
             .get_results::<RolePermission>(db)
     }
 
+    /// Read from [`db`](`Connection`), querying for an entry in the role_permissions table that has 
+    /// (`item_role`,`item_permission`) as it's primary keys
     pub fn read(
         db: &mut Connection,
         item_role: String,
@@ -73,6 +81,8 @@ impl RolePermission {
             .first::<RolePermission>(db)
     }
 
+    /// Read from [`db`](`Connection`), querying for every entry in the role_permissions table that has
+    /// `item_role` as one of its primary keys
     pub fn read_all(db: &mut Connection, item_role: String) -> QueryResult<Vec<Self>> {
         use crate::auth::schema::role_permissions::dsl::*;
 
@@ -82,6 +92,8 @@ impl RolePermission {
             .load::<RolePermission>(db)
     }
 
+    /// Delete the entry in the database's role_permissions table that has 
+    /// (`item_role`,`item_permission`) as it's primary keys
     pub fn delete(
         db: &mut Connection,
         item_role: String,
@@ -95,6 +107,8 @@ impl RolePermission {
             .execute(db)
     }
 
+    /// Delete every entry in the database's role_permissions table that has 
+    /// `item_role`, and an element of`item_permissions` as it's primary keys
     pub fn delete_many(
         db: &mut Connection,
         item_role: String,
@@ -110,6 +124,8 @@ impl RolePermission {
             .execute(db)
     }
 
+    /// Delete the entry in the database's role_permissions table that has 
+    /// `item_role` as one of it's primary keys
     pub fn delete_all(db: &mut Connection, item_role: &str) -> QueryResult<usize> {
         use crate::auth::schema::role_permissions::dsl::*;
 

--- a/create-rust-app/src/auth/permissions/role_permission.rs
+++ b/create-rust-app/src/auth/permissions/role_permission.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::auth::{UTC, schema::*};
+use crate::auth::{schema::*, Utc};
 use crate::database::Connection;
 use crate::diesel::*;
 
@@ -14,7 +14,7 @@ pub struct RolePermission {
     -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- */
     pub role: String,
     pub permission: String,
-    pub created_at: UTC,
+    pub created_at: Utc,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Insertable, AsChangeset)]
@@ -49,9 +49,7 @@ impl RolePermission {
     ) -> QueryResult<usize> {
         use crate::auth::schema::role_permissions::dsl::*;
 
-        insert_into(role_permissions)
-            .values(items)
-            .execute(db)
+        insert_into(role_permissions).values(items).execute(db)
     }
 
     #[cfg(not(feature = "database_sqlite"))]
@@ -104,7 +102,7 @@ impl RolePermission {
         diesel::delete(
             role_permissions.filter(role.eq(item_role).and(permission.eq(item_permission))),
         )
-            .execute(db)
+        .execute(db)
     }
 
     /// Delete every entry in the database's role_permissions table that has 
@@ -121,7 +119,7 @@ impl RolePermission {
                 .filter(role.eq(item_role))
                 .filter(permission.eq_any(item_permissions)),
         )
-            .execute(db)
+        .execute(db)
     }
 
     /// Delete the entry in the database's role_permissions table that has 

--- a/create-rust-app/src/auth/permissions/user_permission.rs
+++ b/create-rust-app/src/auth/permissions/user_permission.rs
@@ -13,6 +13,7 @@ use crate::{
     Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Associations, AsChangeset,
 )]
 #[diesel(table_name=user_permissions,belongs_to(User))]
+/// Rust struct modeling an entry in the user_permissions table
 pub struct UserPermission {
     /* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     Add columns here in the same order as the schema
@@ -24,6 +25,7 @@ pub struct UserPermission {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Insertable, AsChangeset)]
 #[diesel(table_name=user_permissions)]
+/// Rust struct modeling mutable data in an entry in the user_permissions table
 pub struct UserPermissionChangeset {
     /* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     Add columns here in the same order as the schema
@@ -34,7 +36,9 @@ pub struct UserPermissionChangeset {
     pub permission: String,
 }
 
+/// CRUD functions for [`UserPermission`]
 impl UserPermission {
+    /// Create an entry in the database's user_permissions table that has the data stored in [`item`](`UserPermissionChangeset`)
     pub fn create(db: &mut Connection, item: &UserPermissionChangeset) -> QueryResult<Self> {
         use crate::auth::schema::user_permissions::dsl::*;
 
@@ -44,6 +48,7 @@ impl UserPermission {
     }
 
     #[cfg(feature="database_sqlite")]
+    /// Create an entry in the database's user_permissions table for each [element](`UserPermissionChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,
         items: Vec<UserPermissionChangeset>,
@@ -56,6 +61,7 @@ impl UserPermission {
     }
 
     #[cfg(not(feature="database_sqlite"))]
+    /// Create an entry in the database's user_permissions table for each [element](`UserPermissionChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,
         items: Vec<UserPermissionChangeset>,
@@ -67,6 +73,8 @@ impl UserPermission {
             .get_result::<UserPermission>(db)
     }
 
+    /// Read from [`db`](`Connection`), querying for an entry in the user_permissions table that has 
+    /// (`item_user_id`,`item_permission`) as it's primary keys
     pub fn read(
         db: &mut Connection,
         item_user_id: ID,
@@ -79,6 +87,8 @@ impl UserPermission {
             .first::<UserPermission>(db)
     }
 
+    /// Read from [`db`](`Connection`), querying for every entry in the user_permissions table that has
+    /// `item_user_id` as one of its primary keys
     pub fn read_all(db: &mut Connection, item_user_id: ID) -> QueryResult<Vec<Self>> {
         use crate::auth::schema::user_permissions::dsl::*;
 
@@ -88,6 +98,8 @@ impl UserPermission {
             .load::<UserPermission>(db)
     }
 
+    /// Delete the entry in the database's user_permissions table that has 
+    /// (`item_user_id`,`item_permission`) as it's primary keys
     pub fn delete(
         db: &mut Connection,
         item_user_id: ID,
@@ -101,6 +113,8 @@ impl UserPermission {
         .execute(db)
     }
 
+    /// Delete every entry in the database's user_permissions table that has 
+    /// `item_user_id`, and an element of`item_permissions` as it's primary keys
     pub fn delete_many(
         db: &mut Connection,
         item_user_id: ID,
@@ -116,6 +130,8 @@ impl UserPermission {
         .execute(db)
     }
 
+    /// Delete the entry in the database's user_permissions table that has 
+    /// `item_user_id` as one of it's primary keys
     pub fn delete_all(db: &mut Connection, item_user_id: ID) -> QueryResult<usize> {
         use crate::auth::schema::user_permissions::dsl::*;
 

--- a/create-rust-app/src/auth/permissions/user_permission.rs
+++ b/create-rust-app/src/auth/permissions/user_permission.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::auth::schema::*;
 use crate::diesel::*;
 use crate::{
-    auth::{user::User, ID, UTC},
+    auth::{user::User, Utc, ID},
     database::Connection,
 };
 
@@ -20,7 +20,7 @@ pub struct UserPermission {
     -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- */
     pub user_id: ID,
     pub permission: String,
-    pub created_at: UTC,
+    pub created_at: Utc,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Insertable, AsChangeset)]
@@ -47,7 +47,7 @@ impl UserPermission {
             .get_result::<UserPermission>(db)
     }
 
-    #[cfg(feature="database_sqlite")]
+    #[cfg(feature = "database_sqlite")]
     /// Create an entry in the database's user_permissions table for each [element](`UserPermissionChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,
@@ -55,12 +55,10 @@ impl UserPermission {
     ) -> QueryResult<usize> {
         use crate::auth::schema::user_permissions::dsl::*;
 
-        insert_into(user_permissions)
-            .values(items)
-            .execute(db)
+        insert_into(user_permissions).values(items).execute(db)
     }
 
-    #[cfg(not(feature="database_sqlite"))]
+    #[cfg(not(feature = "database_sqlite"))]
     /// Create an entry in the database's user_permissions table for each [element](`UserPermissionChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,

--- a/create-rust-app/src/auth/permissions/user_role.rs
+++ b/create-rust-app/src/auth/permissions/user_role.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::auth::schema::*;
 use crate::diesel::*;
 use crate::{
-    auth::{user::User, ID, UTC},
+    auth::{user::User, Utc, ID},
     database::Connection,
 };
 
@@ -20,7 +20,7 @@ pub struct UserRole {
     -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- */
     pub user_id: ID,
     pub role: String,
-    pub created_at: UTC,
+    pub created_at: Utc,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Insertable, AsChangeset)]

--- a/create-rust-app/src/auth/permissions/user_role.rs
+++ b/create-rust-app/src/auth/permissions/user_role.rs
@@ -13,6 +13,7 @@ use crate::{
     Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Associations, AsChangeset,
 )]
 #[diesel(table_name = user_roles, belongs_to(User))]
+/// Rust struct modeling an entry in the user_roles table
 pub struct UserRole {
     /* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     Add columns here in the same order as the schema
@@ -24,6 +25,7 @@ pub struct UserRole {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Insertable, AsChangeset)]
 #[diesel(table_name = user_roles)]
+/// Rust struct modeling mutable data in an entry in the user_roles table
 pub struct UserRoleChangeset {
     /* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     Add columns here in the same order as the schema
@@ -35,6 +37,7 @@ pub struct UserRoleChangeset {
 }
 
 impl UserRole {
+    /// Create an entry in the database's user_roles table that has the data stored in [`item`](`UserRoleChangeset`)
     pub fn create(db: &mut Connection, item: &UserRoleChangeset) -> QueryResult<Self> {
         use crate::auth::schema::user_roles::dsl::*;
 
@@ -44,6 +47,7 @@ impl UserRole {
     }
 
     #[cfg(feature = "database_sqlite")]
+    /// Create an entry in the database's user_roles table for each [element](`UserRoleChangeset`) in `items`
     pub fn create_many(db: &mut Connection, items: Vec<UserRoleChangeset>) -> QueryResult<usize> {
         use crate::auth::schema::user_roles::dsl::*;
 
@@ -51,6 +55,7 @@ impl UserRole {
     }
 
     #[cfg(not(feature = "database_sqlite"))]
+    /// Create an entry in the database's user_roles table for each [element](`UserRoleChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,
         items: Vec<UserRoleChangeset>,
@@ -62,6 +67,8 @@ impl UserRole {
             .get_results::<UserRole>(db)
     }
 
+    /// Read from [`db`](`Connection`), querying for an entry in the user_roles table that has 
+    /// (`item_user_id`,`item_role`) as it's primary keys
     pub fn read(db: &mut Connection, item_user_id: ID, item_role: String) -> QueryResult<Self> {
         use crate::auth::schema::user_roles::dsl::*;
 
@@ -70,6 +77,8 @@ impl UserRole {
             .first::<UserRole>(db)
     }
 
+    /// Read from [`db`](`Connection`), querying for every entry in the user_roles table that has
+    /// `item_user_id` as one of its primary keys
     pub fn read_all(db: &mut Connection, item_user_id: ID) -> QueryResult<Vec<Self>> {
         use crate::auth::schema::user_roles::dsl::*;
 
@@ -79,6 +88,8 @@ impl UserRole {
             .load::<UserRole>(db)
     }
 
+    /// Delete the entry in the database's user_roles table that has 
+    /// (`item_user_id`,`item_role`) as it's primary keys
     pub fn delete(db: &mut Connection, item_user_id: ID, item_role: String) -> QueryResult<usize> {
         use crate::auth::schema::user_roles::dsl::*;
 
@@ -86,6 +97,8 @@ impl UserRole {
             .execute(db)
     }
 
+    /// Delete every entry in the database's user_roles table that has 
+    /// `item_user_id`, and an element of`item_roles` as it's primary keys
     pub fn delete_many(
         db: &mut Connection,
         item_user_id: ID,

--- a/create-rust-app/src/auth/user.rs
+++ b/create-rust-app/src/auth/user.rs
@@ -1,7 +1,7 @@
 use super::schema::*;
 use crate::diesel::*;
 
-use super::{PaginationParams, ID, UTC};
+use super::{PaginationParams, Utc, ID};
 use crate::database::Connection;
 use diesel::QueryResult;
 use serde::{Deserialize, Serialize};
@@ -21,9 +21,9 @@ pub struct User {
     pub hash_password: String,
     pub activated: bool,
 
-    pub created_at: UTC,
+    pub created_at: Utc,
     #[cfg(not(feature = "database_sqlite"))]
-    pub updated_at: UTC,
+    pub updated_at: Utc,
 }
 
 #[tsync::tsync]

--- a/create-rust-app/src/auth/user_session.rs
+++ b/create-rust-app/src/auth/user_session.rs
@@ -2,7 +2,7 @@ use super::schema::*;
 use crate::diesel::*;
 
 use super::user::User;
-use super::{PaginationParams, ID, UTC};
+use super::{PaginationParams, Utc, ID};
 use crate::database::Connection;
 use diesel::QueryResult;
 use serde::{Deserialize, Serialize};
@@ -30,9 +30,9 @@ pub struct UserSession {
     pub refresh_token: String,
     pub device: Option<String>,
 
-    pub created_at: UTC,
+    pub created_at: Utc,
     #[cfg(not(feature = "database_sqlite"))]
-    pub updated_at: UTC,
+    pub updated_at: Utc,
 }
 
 #[tsync::tsync]

--- a/create-rust-app/src/database/mod.rs
+++ b/create-rust-app/src/database/mod.rs
@@ -10,11 +10,13 @@ pub type Pool = r2d2::Pool<ConnectionManager<DbCon>>;
 pub type Connection = PooledConnection<ConnectionManager<DbCon>>;
 
 #[derive(Clone)]
+/// wrapper function for a database pool
 pub struct Database {
     pub pool: Pool,
 }
 
 impl Database {
+    /// create a new [`Database`]
     pub fn new() -> Database {
         let database_url =
             std::env::var("DATABASE_URL").expect("DATABASE_URL environment variable expected.");
@@ -28,6 +30,7 @@ impl Database {
         }
     }
 
+    /// get a [`Connection`] to a database
     pub fn get_connection(&self) -> Connection {
         self.pool.get().unwrap()
     }

--- a/create-rust-app/src/database/mod.rs
+++ b/create-rust-app/src/database/mod.rs
@@ -15,6 +15,12 @@ pub struct Database {
     pub pool: Pool,
 }
 
+impl Default for Database {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Database {
     /// create a new [`Database`]
     pub fn new() -> Database {

--- a/create-rust-app/src/dev/controller.rs
+++ b/create-rust-app/src/dev/controller.rs
@@ -21,13 +21,15 @@ pub struct HealthCheckResponse {
 }
 
 /// /db/query
-pub fn query_db(db: &Database, body: &MySqlQuery) -> Result<String, ()> {
+pub fn query_db(db: &Database, body: &MySqlQuery) -> Result<String, String> {
     let q = format!("SELECT json_agg(q) as json FROM ({}) q;", body.query);
     let mut db = db.pool.get().unwrap();
 
-    let rows = sql_query(q.as_str()).get_result::<MyQueryResult>(&mut db);
+    let rows = sql_query(q.as_str())
+        .get_result::<MyQueryResult>(&mut db)
+        .map_err(|e| e.to_string());
     if rows.is_err() {
-        return Err(());
+        return Err(rows.err().unwrap());
     }
 
     let result = rows.unwrap().json;
@@ -87,6 +89,4 @@ pub fn migrate_db(db: &Database) -> bool {
 }
 
 /// /health
-pub fn health() -> () {
-    ()
-}
+pub fn health() {}

--- a/create-rust-app/src/dev/endpoints/service_actixweb.rs
+++ b/create-rust-app/src/dev/endpoints/service_actixweb.rs
@@ -1,7 +1,7 @@
 use crate::{
     auth::Auth,
     dev::controller,
-    dev::controller::{HealthCheckResponse, MyQueryResult, MySqlQuery},
+    dev::controller::{HealthCheckResponse, MySqlQuery},
     Database,
 };
 use actix_web::{
@@ -15,7 +15,7 @@ use std::ops::Deref;
 async fn query_db(db: Data<Database>, body: Json<MySqlQuery>) -> HttpResponse {
     match controller::query_db(&db, body.deref()) {
         Ok(result) => HttpResponse::Ok().body(result),
-        Err(t) => HttpResponse::InternalServerError().finish(),
+        Err(_) => HttpResponse::InternalServerError().finish(),
     }
 }
 

--- a/create-rust-app/src/lib.rs
+++ b/create-rust-app/src/lib.rs
@@ -39,13 +39,28 @@ pub use mailer::Mailer;
 // extern crate diesel_migrations;
 
 #[derive(Clone)]
+/// 
 pub struct AppData {
+    /// wrapper for SMTP mailing server accessed by chosen web framework
+    /// 
+    /// see [`Mailer`]
     pub mailer: Mailer,
+    /// db agnostic wrapper for databases accessed by chosen web framework
+    /// 
+    /// see [`Database`]
     pub database: Database,
     #[cfg(feature = "plugin_storage")]
+    /// wrapper for Amazon S3 cloud file storage service accessed by chosen web framework
+    /// 
+    /// see [`Storage`]
     pub storage: storage::Storage,
 }
 
+/// ensures required environment variables are present,
+///  
+/// initialize a [`Mailer`], [`Database`], and [`Storage`] (is `Storage` plugin was enabled ("plugin_storage" feature enabled))
+/// 
+/// and wraps them in a [`AppData`] struct that is then returned
 pub fn setup() -> AppData {
     // Only load dotenv in development
     #[cfg(debug_assertions)]
@@ -82,6 +97,7 @@ pub fn setup() -> AppData {
 use poem;
 
 #[cfg(feature = "backend_poem")]
+/// TODO: documentation
 pub async fn not_found(_: poem::error::NotFoundError) -> poem::Response {
     let json = serde_json::json!({
         "success": false,

--- a/create-rust-app/src/logger.rs
+++ b/create-rust-app/src/logger.rs
@@ -1,21 +1,26 @@
 use poem::{async_trait, Endpoint, IntoResponse, Middleware, Request, Response, Result};
 
+/// Logger middleware that provides similar functionality as [`actix_web::middleware::Logger`] 
+/// for the poem backend
 pub struct Logger;
 
 impl<E: Endpoint> Middleware<E> for Logger {
     type Output = LogImpl<E>;
 
+    /// TODO: documentation
     fn transform(&self, ep: E) -> Self::Output {
         LogImpl(ep)
     }
 }
 
+/// TODO: documentation
 pub struct LogImpl<E>(E);
 
 #[async_trait]
 impl<E: Endpoint> Endpoint for LogImpl<E> {
     type Output = Response;
 
+    /// TODO: documentation
     async fn call(&self, req: Request) -> Result<Self::Output> {
         println!(">  REQUEST: {}", req.uri().path());
         let res = self.0.call(req).await;

--- a/create-rust-app/src/logger.rs
+++ b/create-rust-app/src/logger.rs
@@ -20,7 +20,7 @@ pub struct LogImpl<E>(E);
 impl<E: Endpoint> Endpoint for LogImpl<E> {
     type Output = Response;
 
-    /// TODO: documentation
+    /// Logs requests recieved by the server, as well as the associated responses
     async fn call(&self, req: Request) -> Result<Self::Output> {
         println!(">  REQUEST: {}", req.uri().path());
         let res = self.0.call(req).await;

--- a/create-rust-app/src/mailer.rs
+++ b/create-rust-app/src/mailer.rs
@@ -4,15 +4,39 @@ use lettre::transport::stub::StubTransport;
 use lettre::{SmtpTransport, Transport};
 
 #[derive(Clone)]
+/// struct used to handle sending emails from
 pub struct Mailer {
+    /// the email address emails should be sent from
+    /// 
+    /// set by the `SMTP_FROM_ADDRESS` environment variable
     pub from_address: String,
+    /// the smtp server to connect to for purposes of sending emails
+    /// 
+    /// set by the `SMTP_SERVER` environment variable
     pub smtp_server: String,
+    /// username used to log into `SMTP_SERVER`
+    /// 
+    /// set by the `SMTP_USERNAME` environment variable
     pub smtp_username: String,
+    /// the password used to log into `SMTP_SERVER`
+    /// 
+    /// set by the `SMTP_PASSWORD' environment variable
     pub smtp_password: String,
+    /// whether or not emails should actually be sent when requested
+    /// 
+    /// it may be useful to set this to false in some devolopment environments
+    /// while setting it to true in production
+    /// 
+    /// set by the `SEND_MAIL` environment variable
     pub actually_send: bool,
 }
 
 impl Mailer {
+    /// using information stored in the `SMTP_FROM_ADDRESS`, `SMTP_SERVER`, `SMTP_USERNAME`, `SMTP_PASSWORD`, and `SEND_MAIL`
+    /// environment variables to connect to a remote SMTP server, 
+    /// 
+    /// allows webservers to send emails to users for purposes
+    /// like marketing, user authentification, etc.
     pub fn new() -> Mailer {
         Mailer::check_environment_variables();
 
@@ -34,6 +58,10 @@ impl Mailer {
         };
     }
 
+    /// checks that the required environment variables are set
+    /// 
+    /// prints messages denoting which, if any, of the required 
+    /// environment variables were not set
     pub fn check_environment_variables() {
         if std::env::var("SMTP_FROM_ADDRESS").is_err() {
             println!("Note: Mailing disabled; 'SMTP_FROM_ADDRESS' not set.");
@@ -60,6 +88,16 @@ impl Mailer {
         }
     }
 
+    /// send an email with the specifified content and subject to the specified user
+    /// 
+    /// will only send an email if the `SEND_MAIL` environment variable was set to true when 
+    /// this mailer was initialized.
+    /// 
+    /// # Arguments
+    /// * `to` - a string slice that holds the email address of the intended recipient
+    /// * `subject` - subject field of the email
+    /// * `text` - text content of the email
+    /// * `html` - html content of the email
     pub fn send(&self, to: &str, subject: &str, text: &str, html: &str) {
         let email = Message::builder()
             .to(to.parse().unwrap())

--- a/create-rust-app/src/mailer.rs
+++ b/create-rust-app/src/mailer.rs
@@ -4,7 +4,7 @@ use lettre::transport::stub::StubTransport;
 use lettre::{SmtpTransport, Transport};
 
 #[derive(Clone)]
-/// struct used to handle sending emails from
+/// struct used to handle sending emails
 pub struct Mailer {
     /// the email address emails should be sent from
     /// 

--- a/create-rust-app/src/mailer.rs
+++ b/create-rust-app/src/mailer.rs
@@ -31,31 +31,39 @@ pub struct Mailer {
     pub actually_send: bool,
 }
 
+impl Default for Mailer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Mailer {
     /// using information stored in the `SMTP_FROM_ADDRESS`, `SMTP_SERVER`, `SMTP_USERNAME`, `SMTP_PASSWORD`, and `SEND_MAIL`
     /// environment variables to connect to a remote SMTP server, 
     /// 
     /// allows webservers to send emails to users for purposes
     /// like marketing, user authentification, etc.
-    pub fn new() -> Mailer {
+    pub fn new() -> Self {
         Mailer::check_environment_variables();
 
-        let from_address: String =
-            std::env::var("SMTP_FROM_ADDRESS").unwrap_or("create-rust-app@localhost".to_string());
-        let smtp_server: String = std::env::var("SMTP_SERVER").unwrap_or("".to_string());
-        let smtp_username: String = std::env::var("SMTP_USERNAME").unwrap_or("".to_string());
-        let smtp_password: String = std::env::var("SMTP_PASSWORD").unwrap_or("".to_string());
+        let from_address: String = std::env::var("SMTP_FROM_ADDRESS")
+            .unwrap_or_else(|_| "create-rust-app@localhost".to_string());
+        let smtp_server: String = std::env::var("SMTP_SERVER").unwrap_or_else(|_| "".to_string());
+        let smtp_username: String =
+            std::env::var("SMTP_USERNAME").unwrap_or_else(|_| "".to_string());
+        let smtp_password: String =
+            std::env::var("SMTP_PASSWORD").unwrap_or_else(|_| "".to_string());
         let actually_send: bool = std::env::var("SEND_MAIL")
-            .unwrap_or("false".to_string())
+            .unwrap_or_else(|_| "false".to_string())
             .eq_ignore_ascii_case("true");
 
-        return Mailer {
+        Mailer {
             from_address,
             smtp_server,
             smtp_username,
             smtp_password,
             actually_send,
-        };
+        }
     }
 
     /// checks that the required environment variables are set

--- a/create-rust-app/src/storage/attachment_blob.rs
+++ b/create-rust-app/src/storage/attachment_blob.rs
@@ -1,11 +1,11 @@
 use serde::{Deserialize, Serialize};
 
-use crate::Connection;
 use crate::diesel::*;
-use crate::storage::{ID, schema, schema::*, UTC};
+use crate::storage::{schema, schema::*, Utc, ID};
+use crate::Connection;
 
 #[derive(
-Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Identifiable, AsChangeset,
+    Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Identifiable, AsChangeset,
 )]
 #[diesel(table_name = attachment_blobs)]
 pub struct AttachmentBlob {
@@ -18,7 +18,7 @@ pub struct AttachmentBlob {
     pub checksum: String,
     pub service_name: String,
 
-    pub created_at: UTC,
+    pub created_at: Utc,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Insertable, AsChangeset)]

--- a/create-rust-app/src/util/actix_web_utils.rs
+++ b/create-rust-app/src/util/actix_web_utils.rs
@@ -10,8 +10,8 @@ use tera::Context;
 pub fn render_single_page_application(route: &str, view: &str) -> Scope {
     use actix_web::web::Data;
 
-    let route = route.strip_prefix("/").unwrap_or(route);
-    let view = view.strip_prefix("/").unwrap_or(view);
+    let route = route.strip_prefix('/').unwrap_or(route);
+    let view = view.strip_prefix('/').unwrap_or(view);
 
     actix_web::web::scope(&format!("/{}{{tail:(/.*)?}}", route))
         .app_data(Data::new(SinglePageApplication {
@@ -21,7 +21,7 @@ pub fn render_single_page_application(route: &str, view: &str) -> Scope {
 }
 
 async fn render_spa_handler(
-    req: HttpRequest,
+    _req: HttpRequest,
     spa_info: web::Data<SinglePageApplication>,
 ) -> HttpResponse {
     let content = TEMPLATES

--- a/create-rust-app/src/util/net.rs
+++ b/create-rust-app/src/util/net.rs
@@ -1,10 +1,9 @@
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6, TcpListener, ToSocketAddrs};
 
 fn test_bind<A: ToSocketAddrs>(addr: A) -> bool {
-    match TcpListener::bind(addr).map(|t| t.local_addr().is_ok()) {
-        Ok(result) => result,
-        Err(_) => false,
-    }
+    TcpListener::bind(addr)
+        .map(|t| t.local_addr().is_ok())
+        .unwrap_or(false)
 }
 
 pub fn is_port_free(port: u16) -> bool {

--- a/create-rust-app/src/util/template_utils.rs
+++ b/create-rust-app/src/util/template_utils.rs
@@ -26,14 +26,15 @@ lazy_static! {
     };
 }
 
-pub const DEFAULT_TEMPLATE: &'static str = "index.html";
+pub const DEFAULT_TEMPLATE: &str = "index.html";
 pub fn to_template_name(request_path: &str) -> &'_ str {
-    let request_path = request_path.strip_prefix("/").unwrap();
-    return if request_path.eq("") {
+    let request_path = request_path.strip_prefix('/').unwrap();
+
+    if request_path.eq("") {
         DEFAULT_TEMPLATE
     } else {
         request_path
-    };
+    }
 }
 
 /// This implements the {{ bundle(name="index.tsx") }} function for our templates
@@ -42,7 +43,7 @@ impl tera::Function for InjectBundle {
     fn call(&self, args: &HashMap<String, serde_json::Value>) -> tera::Result<serde_json::Value> {
         match args.get("name") {
             Some(val) => {
-                return match tera::from_value::<String>(val.clone()) {
+                match tera::from_value::<String>(val.clone()) {
                     Ok(bundle_name) => {
                         let inject: String;
 
@@ -103,7 +104,7 @@ impl tera::Function for InjectBundle {
                         Ok(tera::to_value(inject).unwrap())
                     }
                     Err(_) => panic!("No bundle named '{:#?}'", val),
-                };
+                }
             }
             None => Err("oops".into()),
         }
@@ -114,6 +115,7 @@ impl tera::Function for InjectBundle {
     }
 }
 
+#[allow(dead_code, non_snake_case)]
 #[derive(serde::Deserialize)]
 pub struct ViteManifestEntry {
     // Script content to load for this entry

--- a/create-rust-app_cli/src/content/migration.rs
+++ b/create-rust-app_cli/src/content/migration.rs
@@ -11,12 +11,8 @@ fn get_migration_number() -> usize {
         logger::message("Migrations directory does not exist, create it?");
     }
 
-    let count = match migrations_dir.read_dir().unwrap() {
-        v => v.count(),
-        // Err(_) => 3 // guess the migration number
-    };
-
-    return count;
+    let v = migrations_dir.read_dir().unwrap();
+    v.count()
 }
 
 pub fn create(name: &str, up: &str, down: &str) -> Result<()> {

--- a/create-rust-app_cli/src/content/model.rs
+++ b/create-rust-app_cli/src/content/model.rs
@@ -30,11 +30,11 @@ fn config(resource_name: &str) -> ModelConfig {
     let file_name = model_name.to_snake_case();
     let table_name = model_name.to_table_case();
 
-    return ModelConfig {
-        model_name: model_name,
-        file_name: file_name,
-        table_name: table_name,
-    };
+    ModelConfig {
+        model_name,
+        file_name,
+        table_name,
+    }
 }
 
 fn generate(resource_name: &str) -> Model {
@@ -118,7 +118,7 @@ fn generate(resource_name: &str) -> Model {
         .replace("$TABLE_NAME", config.table_name.as_str());
 
     Model {
-        config: config,
+        config,
         file_contents: contents,
     }
 }

--- a/create-rust-app_cli/src/content/project.rs
+++ b/create-rust-app_cli/src/content/project.rs
@@ -349,8 +349,8 @@ pub fn create(project_name: &str, creation_options: CreationOptions) -> Result<(
         r#"chrono = { version = "0.4.19", features = ["serde"] }"#,
     )?;
     // todo: move these deps to the helper crate (./create-rust-app/Cargo.toml) behind feature flags
-    add_dependency(&project_dir, "tsync", r#"tsync = "1""#)?;
-    add_dependency(&project_dir, "dsync", r#"dsync = "0""#)?;
+    add_dependency(&project_dir, "tsync", r#"tsync = "1.6.0""#)?;
+    add_dependency(&project_dir, "dsync", r#"dsync = "0.0.5""#)?;
     add_dependency(
         &project_dir,
         "diesel",

--- a/create-rust-app_cli/src/content/project.rs
+++ b/create-rust-app_cli/src/content/project.rs
@@ -126,7 +126,7 @@ pub fn remove_non_framework_files(
         let entry = entry.unwrap();
 
         let file = entry.path();
-        let path = file.clone().to_str().unwrap().to_string();
+        let path = file.to_str().unwrap().to_string();
 
         if path.ends_with("+actix_web") {
             if framework != BackendFramework::ActixWeb {
@@ -164,23 +164,20 @@ pub fn remove_non_framework_files(
     Ok(())
 }
 
-pub fn remove_non_database_files(
-    project_dir: &PathBuf,
-    database: BackendDatabase,
-) -> Result<()> {
+pub fn remove_non_database_files(project_dir: &PathBuf, database: BackendDatabase) -> Result<()> {
     /* Choose framework-specific files */
     for entry in WalkDir::new(project_dir) {
         let entry = entry.unwrap();
 
         let file = entry.path();
-        let path = file.clone().to_str().unwrap().to_string();
+        let path = file.to_str().unwrap().to_string();
 
         if path.ends_with("+database_postgres") {
             if database != BackendDatabase::Postgres {
                 logger::remove_file_msg(&format!("{:#?}", &file));
                 std::fs::remove_file(file)?;
             };
-            if database == BackendDatabase::Postgres{
+            if database == BackendDatabase::Postgres {
                 let dest = file.with_extension(
                     file.extension()
                         .unwrap()
@@ -276,14 +273,14 @@ pub fn create(project_name: &str, creation_options: CreationOptions) -> Result<(
 
     // cleanup: remove src/main.rs
     logger::command_msg("rm src/main.rs");
-    let mut main_file = PathBuf::from(project_dir.clone());
+    let mut main_file = project_dir.clone();
     main_file.push("src");
     main_file.push("main.rs");
     std::fs::remove_file(main_file)?;
 
     // cleanup: remove src/
     logger::command_msg("rmdir src/main.rs");
-    let mut src_folder = PathBuf::from(project_dir.clone());
+    let mut src_folder = project_dir.clone();
     src_folder.push("src");
     std::fs::remove_dir(src_folder)?;
 
@@ -354,10 +351,13 @@ pub fn create(project_name: &str, creation_options: CreationOptions) -> Result<(
     add_dependency(
         &project_dir,
         "diesel",
-        &format!(r#"diesel = {{ version="2.0.0-rc.1", default-features = false, features = ["{db}", "r2d2", "chrono"] }}"#, db = match database {
-            BackendDatabase::Postgres => "postgres",
-            BackendDatabase::Sqlite => "sqlite",
-        }),
+        &format!(
+            r#"diesel = {{ version="2.0.0-rc.1", default-features = false, features = ["{db}", "r2d2", "chrono"] }}"#,
+            db = match database {
+                BackendDatabase::Postgres => "postgres",
+                BackendDatabase::Sqlite => "sqlite",
+            }
+        ),
     )?;
     add_dependency(
         &project_dir,
@@ -419,9 +419,12 @@ pub fn create(project_name: &str, creation_options: CreationOptions) -> Result<(
         env_example_file.push(".env.example");
         env_file.push(".env");
         let contents = std::fs::read_to_string(&env_example_file)?;
-        let contents = contents.replace("postgres://postgres:postgres@localhost/database", "dev.sqlite");
+        let contents = contents.replace(
+            "postgres://postgres:postgres@localhost/database",
+            "dev.sqlite",
+        );
         std::fs::write(env_example_file, contents.clone())?;
-        std::fs::write(env_file, contents.clone())?;
+        std::fs::write(env_file, contents)?;
     }
 
     /*
@@ -493,7 +496,7 @@ pub fn create(project_name: &str, creation_options: CreationOptions) -> Result<(
 
             logger::command_msg(&format!("git config user.name {:#?}", &input));
 
-            if input.len() > 0
+            if !input.is_empty()
                 && git::set_config(&project_dir, "user.name", &input)
                 && git::check_config(&project_dir, "user.name")
             {
@@ -522,7 +525,7 @@ pub fn create(project_name: &str, creation_options: CreationOptions) -> Result<(
 
             logger::command_msg(&format!("git config user.email {:#?}", &input));
 
-            if input.len() > 0
+            if !input.is_empty()
                 && git::set_config(&project_dir, "user.email", &input)
                 && git::check_config(&project_dir, "user.email")
             {

--- a/create-rust-app_cli/src/content/service.rs
+++ b/create-rust-app_cli/src/content/service.rs
@@ -55,10 +55,10 @@ fn config(service_name: &str) -> ServiceConfig {
     let model_name = service_name.to_pascal_case();
     let file_name = model_name.to_snake_case();
 
-    return ServiceConfig {
+    ServiceConfig {
         model_name,
         file_name,
-    };
+    }
 }
 
 fn generate_poem(service_name: &str) -> Service {

--- a/create-rust-app_cli/src/main.rs
+++ b/create-rust-app_cli/src/main.rs
@@ -15,13 +15,13 @@ use content::project;
 use dialoguer::{theme::ColorfulTheme, Input, MultiSelect, Select};
 use utils::{fs, logger};
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BackendFramework {
     ActixWeb,
     Poem,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BackendDatabase {
     Postgres,
     Sqlite,
@@ -67,13 +67,10 @@ fn main() -> Result<()> {
         current_dir = PathBuf::from(unknown_opts.target.unwrap());
 
         if current_dir.exists() {
-            logger::error(
-                &format!(
-                    "Cannot create a project: {:#?} already exists.",
-                    &current_dir
-                )
-                .to_string(),
-            );
+            logger::error(&format!(
+                "Cannot create a project: {:#?} already exists.",
+                &current_dir
+            ));
             return Ok(());
         }
     }
@@ -122,14 +119,16 @@ fn create_project() -> anyhow::Result<()> {
 
     let project_name = create_opts.target;
 
-    if project_name.len() == 0 {
+    if project_name.is_empty() {
         logger::error("Please provide a project name");
 
         return Ok(());
     }
 
     logger::message("Please select plugins for your new project:");
-    logger::message("Use UP/DOWN arrows to navigate, SPACE to enable/disable a plugin, and ENTER to confirm.");
+    logger::message(
+        "Use UP/DOWN arrows to navigate, SPACE to enable/disable a plugin, and ENTER to confirm.",
+    );
 
     let items = vec![
         "Authentication Plugin: local email-based authentication",
@@ -143,11 +142,11 @@ fn create_project() -> anyhow::Result<()> {
         .defaults(&[true, true, true, true, true])
         .interact()?;
 
-    let add_plugin_auth = chosen.iter().position(|x| *x == 0).is_some();
-    let add_plugin_container = chosen.iter().position(|x| *x == 1).is_some();
-    let add_plugin_dev = chosen.iter().position(|x| *x == 2).is_some();
-    let add_plugin_storage = chosen.iter().position(|x| *x == 3).is_some();
-    let add_plugin_graphql = chosen.iter().position(|x| *x == 4).is_some();
+    let add_plugin_auth = chosen.iter().any(|x| *x == 0);
+    let add_plugin_container = chosen.iter().any(|x| *x == 1);
+    let add_plugin_dev = chosen.iter().any(|x| *x == 2);
+    let add_plugin_storage = chosen.iter().any(|x| *x == 3);
+    let add_plugin_graphql = chosen.iter().any(|x| *x == 4);
 
     let mut features: Vec<String> = vec![];
     if add_plugin_dev {
@@ -187,7 +186,7 @@ fn create_project() -> anyhow::Result<()> {
     project_dir.push(project_name);
     // !
     std::env::set_current_dir(project_dir.clone())
-        .expect(&format!("Unable to change into {:#?}", project_dir.clone()));
+        .unwrap_or_else(|_| panic!("Unable to change into {:#?}", project_dir.clone()));
 
     //
     // Note: we're in the project dir from here on out
@@ -302,7 +301,7 @@ fn configure_project() -> Result<()> {
                         .default("".into())
                         .interact_text()?;
 
-                    if resource_name.len() == 0 {
+                    if resource_name.is_empty() {
                         return Ok(());
                     }
 

--- a/create-rust-app_cli/src/plugins/auth.rs
+++ b/create-rust-app_cli/src/plugins/auth.rs
@@ -179,7 +179,7 @@ import { ResetPage } from './containers/ResetPage'"#,
         created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
         PRIMARY KEY (role, permission)
       );
-    "#}
+    "#},
             },
             indoc! {r#"
       DROP TABLE user_permissions;

--- a/create-rust-app_cli/src/plugins/dev.rs
+++ b/create-rust-app_cli/src/plugins/dev.rs
@@ -53,10 +53,7 @@ impl Plugin for Dev {
     "react-query": "^3.21.0""#,
         )?;
 
-        fs::append(
-            "frontend/src/dev.tsx",
-            "\nimport './setupDevelopment'"
-        )?;
+        fs::append("frontend/src/dev.tsx", "\nimport './setupDevelopment'")?;
 
         match install_config.backend_framework {
             BackendFramework::ActixWeb => {

--- a/create-rust-app_cli/src/plugins/mod.rs
+++ b/create-rust-app_cli/src/plugins/mod.rs
@@ -35,7 +35,7 @@ pub trait Plugin {
 
         let output = std::str::from_utf8(&output.stdout).unwrap();
 
-        if output.len() > 0 {
+        if !output.is_empty() {
             logger::error(
                 "Please stash and remove any changes (staged, unstaged, and untracked files)",
             );
@@ -94,7 +94,7 @@ pub fn install(plugin: impl Plugin, install_config: InstallConfig) -> Result<()>
 
     plugin.before_install()?;
     plugin.install(install_config.clone())?;
-    plugin.after_install(install_config.clone())?;
+    plugin.after_install(install_config)?;
 
     Ok(())
 }

--- a/create-rust-app_cli/src/plugins/storage.rs
+++ b/create-rust-app_cli/src/plugins/storage.rs
@@ -119,7 +119,7 @@ CREATE TABLE attachments(
 
   created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
-"#}
+"#},
             },
             indoc! {r#"
 DROP TABLE attachment_blobs;

--- a/create-rust-app_cli/src/qsync/mod.rs
+++ b/create-rust-app_cli/src/qsync/mod.rs
@@ -11,7 +11,7 @@ use structopt::StructOpt;
 
 pub use processor::process;
 
-const DESCRIPTION: &'static str = env!("CARGO_PKG_DESCRIPTION");
+const DESCRIPTION: &str = env!("CARGO_PKG_DESCRIPTION");
 
 #[allow(dead_code)]
 #[derive(Debug, StructOpt, Clone)]

--- a/create-rust-app_cli/src/qsync/params.rs
+++ b/create-rust-app_cli/src/qsync/params.rs
@@ -1,27 +1,26 @@
 pub fn is_primitive_type(ty: String) -> bool {
-    match ty.as_str() {
-        "i8" => true,
-        "u8" => true,
-        "i16" => true,
-        "u16" => true,
-        "i32" => true,
-        "u32" => true,
-        "i64" => true,
-        "u64" => true,
-        "i128" => true,
-        "u128" => true,
-        "isize" => true,
-        "usize" => true,
-        "f32" => true,
-        "f64" => true,
-        "bool" => true,
-        "char" => true,
-        "str" => true,
-        "String" => true,
-        "NaiveDateTime" => true,
-        "DateTime" => true,
-        _ => false,
-    }
+    matches!(
+        ty.as_str(),
+        "i8" | "u8"
+            | "i16"
+            | "u16"
+            | "i32"
+            | "u32"
+            | "i64"
+            | "u64"
+            | "i128"
+            | "u128"
+            | "isize"
+            | "usize"
+            | "f32"
+            | "f64"
+            | "bool"
+            | "char"
+            | "str"
+            | "String"
+            | "NaiveDateTime"
+            | "DateTime"
+    )
 }
 
 // TODO: leverage TSYNC

--- a/create-rust-app_cli/src/qsync/processor.rs
+++ b/create-rust-app_cli/src/qsync/processor.rs
@@ -24,7 +24,7 @@ struct QsyncAttributeProps {
 
 fn has_qsync_attribute(
     _is_debug: bool,
-    attributes: &Vec<syn::Attribute>,
+    attributes: &[syn::Attribute],
 ) -> Option<QsyncAttributeProps> {
     let mut qsync_props = QsyncAttributeProps {
         is_mutation: false,
@@ -40,9 +40,7 @@ fn has_qsync_attribute(
 
     for attr in attributes.iter() {
         let last_segment = attr.path.segments.last();
-        if last_segment.is_some() {
-            let last_segment = last_segment.unwrap();
-
+        if let Some(last_segment) = last_segment {
             // if last_segment
             //     .clone()
             //     .ident
@@ -122,19 +120,18 @@ mod processor_tests {
 
 #[derive(Debug)]
 pub enum HttpVerb {
-    GET,
-    POST,
-    PUT,
-    DELETE,
-    UNKNOWN,
+    Get,
+    Post,
+    Put,
+    Delete,
+    Unknown,
 }
-
 enum ParamType {
-    AUTH,
-    QUERY,
-    BODY,
-    PATH,
-    UNKNOWN,
+    Auth,
+    Query,
+    Body,
+    Path,
+    Unknown,
 }
 
 struct InputType {
@@ -147,22 +144,12 @@ fn get_api_fn_input_param_type(pat_type: PatType, type_path: TypePath) -> InputT
     let mut arg_name: String = "unknown".to_string();
     let mut arg_type: String = "any".to_string();
 
-    match *pat_type.pat {
-        Pat::TupleStruct(tuple_struct) => {
-            let ident_elem = tuple_struct.pat.elems.last();
-            if ident_elem.is_some() {
-                let ident_elem = ident_elem.unwrap().clone();
-
-                match ident_elem {
-                    Pat::Ident(ident) => {
-                        let ident = ident.ident;
-                        arg_name = ident.to_string();
-                    }
-                    _ => { /* failed to capture identifier for hook argument */ }
-                }
-            }
+    if let Pat::TupleStruct(tuple_struct) = *pat_type.pat {
+        let ident_elem = tuple_struct.pat.elems.last();
+        if let Some(Pat::Ident(ident)) = ident_elem {
+            let ident = ident.ident.clone();
+            arg_name = ident.to_string();
         }
-        _ => { /* failed to determine name of arg */ }
     }
 
     let segments: syn::punctuated::Punctuated<syn::PathSegment, syn::token::Colon2> =
@@ -170,37 +157,32 @@ fn get_api_fn_input_param_type(pat_type: PatType, type_path: TypePath) -> InputT
 
     let last_segment = segments.last();
 
-    if last_segment.is_some() {
-        let last_segment = last_segment.unwrap();
-
+    if let Some(last_segment) = last_segment {
         let param_type = match last_segment.clone().ident.to_string().as_str() {
-            "Path" => ParamType::PATH,
-            "Json" => ParamType::BODY,
-            "Form" => ParamType::BODY,
-            "Query" => ParamType::QUERY,
-            "Auth" => ParamType::AUTH,
-            _ => ParamType::UNKNOWN,
+            "Path" => ParamType::Path,
+            "Json" => ParamType::Body,
+            "Form" => ParamType::Body,
+            "Query" => ParamType::Query,
+            "Auth" => ParamType::Auth,
+            _ => ParamType::Unknown,
         };
 
-        match last_segment.clone().arguments {
-            PathArguments::AngleBracketed(angled) => {
-                for arg in angled.args {
-                    arg_type = generic_to_typsecript_type(&arg);
-                }
+        if let PathArguments::AngleBracketed(angled) = last_segment.clone().arguments {
+            for arg in angled.args {
+                arg_type = generic_to_typsecript_type(&arg);
             }
-            _ => { /* could not find type for param */ }
         }
 
         InputType {
-            param_type: param_type,
-            arg_name: arg_name.to_string(),
-            arg_type: arg_type.to_string(),
+            param_type,
+            arg_name,
+            arg_type,
         }
     } else {
         InputType {
-            param_type: ParamType::UNKNOWN,
-            arg_name: arg_name.to_string(),
-            arg_type: arg_type.to_string(),
+            param_type: ParamType::Unknown,
+            arg_name,
+            arg_type,
         }
     }
 }
@@ -214,8 +196,8 @@ fn extract_path_params_from_hook_endpoint_url(hook: &mut Hook) {
     for path_param_text in re.find_iter(hook.endpoint_url.as_str()) {
         let path_param_text = path_param_text
             .as_str()
-            .trim_start_matches("{")
-            .trim_end_matches("}")
+            .trim_start_matches('{')
+            .trim_end_matches('}')
             .to_string();
         hook.path_params.push(HookPathParam {
             hook_arg_name: path_param_text,
@@ -225,43 +207,37 @@ fn extract_path_params_from_hook_endpoint_url(hook: &mut Hook) {
 }
 
 fn extract_endpoint_information(
-    input_path: &PathBuf,
+    input_path: &Path,
     attributes: &Vec<syn::Attribute>,
     hook: &mut Hook,
 ) {
-    let mut verb = HttpVerb::UNKNOWN;
+    let mut verb = HttpVerb::Unknown;
     let mut path = "".to_string();
 
     for attr in attributes {
         let last_segment = attr.path.segments.last();
-        if last_segment.is_some() {
-            let potential_verb = last_segment.unwrap().ident.to_string();
+        if let Some(potential_verb) = last_segment {
+            let potential_verb = potential_verb.ident.to_string();
 
             if potential_verb.eq_ignore_ascii_case("get") {
-                verb = HttpVerb::GET;
+                verb = HttpVerb::Get;
             } else if potential_verb.eq_ignore_ascii_case("post") {
-                verb = HttpVerb::POST;
+                verb = HttpVerb::Post;
             } else if potential_verb.eq_ignore_ascii_case("put") {
-                verb = HttpVerb::PUT;
+                verb = HttpVerb::Put;
             } else if potential_verb.eq_ignore_ascii_case("delete") {
-                verb = HttpVerb::DELETE;
+                verb = HttpVerb::Delete;
             }
         }
 
-        if !matches!(verb, HttpVerb::UNKNOWN) {
+        if !matches!(verb, HttpVerb::Unknown) {
             for token in attr.clone().tokens {
-                match token {
-                    syn::__private::quote::__private::TokenTree::Group(g) => {
-                        for x in g.stream() {
-                            match x {
-                                syn::__private::quote::__private::TokenTree::Literal(lit) => {
-                                    path = lit.to_string();
-                                }
-                                _ => {}
-                            }
+                if let syn::__private::quote::__private::TokenTree::Group(g) = token {
+                    for x in g.stream() {
+                        if let syn::__private::quote::__private::TokenTree::Literal(lit) = x {
+                            path = lit.to_string();
                         }
                     }
-                    _ => {}
                 }
             }
         }
@@ -272,13 +248,13 @@ fn extract_endpoint_information(
         .unwrap_or_default()
         .to_str()
         .unwrap_or_default()
-        .trim_end_matches("/");
+        .trim_end_matches('/');
 
     // the part extracted from the attribute, for example: `#[post("/{id}"]`
     let handler_path = path
         .trim_matches('"')
         .trim_start_matches('/')
-        .trim_end_matches("/");
+        .trim_end_matches('/');
     let handler_path = if !handler_path.is_empty() {
         "/".to_string() + handler_path
     } else {
@@ -298,7 +274,7 @@ struct BuildState /*<'a>*/ {
     pub is_debug: bool,
 }
 
-fn generate_hook_name(input_path: &PathBuf, fn_name: String) -> String {
+fn generate_hook_name(input_path: &Path, fn_name: String) -> String {
     let mut s: Vec<String> = vec![];
 
     let mut copy = false;
@@ -320,7 +296,7 @@ fn generate_hook_name(input_path: &PathBuf, fn_name: String) -> String {
     two.join("")
 }
 
-fn generate_query_key_base(input_path: &PathBuf) -> String {
+fn generate_query_key_base(input_path: &Path) -> String {
     let mut s: Vec<String> = vec![];
 
     let mut copy = false;
@@ -373,120 +349,107 @@ fn process_service_file(input_path: PathBuf, state: &mut BuildState) {
     let syntax = syntax.unwrap();
 
     for item in syntax.items {
-        match item {
-            syn::Item::Fn(exported_fn) => {
-                let qsync_props = has_qsync_attribute(state.is_debug, &exported_fn.attrs);
+        if let syn::Item::Fn(exported_fn) = item {
+            let qsync_props = has_qsync_attribute(state.is_debug, &exported_fn.attrs);
 
-                let has_qsync_attribute = qsync_props.is_some();
+            let has_qsync_attribute = qsync_props.is_some();
 
-                if state.is_debug {
-                    if has_qsync_attribute {
-                        println!(
-                            "Encountered #[get|post|put|delete] struct: {}",
-                            exported_fn.sig.ident.to_string()
-                        );
-                    } else {
-                        println!(
-                            "Encountered non-query struct: {}",
-                            exported_fn.sig.ident.to_string()
-                        );
-                    }
-                }
-
+            if state.is_debug {
                 if has_qsync_attribute {
-                    let qsync_props = qsync_props.unwrap();
-                    let mut hook = Hook {
-                        uses_auth: false,
-                        endpoint_url: "".to_string(),
-                        endpoint_verb: HttpVerb::UNKNOWN,
-                        is_mutation: qsync_props.is_mutation,
-                        return_type: qsync_props.return_type,
-                        hook_name: generate_hook_name(
-                            &input_path,
-                            exported_fn.sig.ident.to_string(),
-                        ),
-                        query_key_base: generate_query_key_base(&input_path),
-                        body_params: vec![],
-                        path_params: vec![],
-                        query_params: vec![],
-                    };
-
-                    extract_endpoint_information(&input_path, &exported_fn.attrs, &mut hook);
-                    extract_path_params_from_hook_endpoint_url(&mut hook);
-
-                    let mut arg_index = 0;
-                    let num_args = exported_fn.sig.inputs.len() - 1;
-                    for arg in exported_fn.sig.inputs {
-                        match arg.clone() {
-                            FnArg::Typed(typed_arg) => match *typed_arg.clone().ty {
-                                Type::Path(type_path) => {
-                                    let input_type =
-                                        get_api_fn_input_param_type(typed_arg.clone(), type_path);
-
-                                    match input_type.param_type {
-                                        ParamType::AUTH => {
-                                            if state.is_debug {
-                                                println!("\t> ParamType::AUTH",);
-                                            }
-                                            hook.uses_auth = true;
-                                        }
-                                        ParamType::BODY => {
-                                            if state.is_debug {
-                                                println!(
-                                                    "\t> ParamType::BODY '{}: {}'",
-                                                    input_type.arg_name, input_type.arg_type
-                                                );
-                                            }
-                                            hook.body_params.push(HookBodyParam {
-                                                hook_arg_name: input_type.arg_name,
-                                                hook_arg_type: input_type.arg_type,
-                                            });
-                                        }
-                                        ParamType::PATH => {
-                                            if state.is_debug {
-                                                println!("\t> ParamType::PATH '{}: {}', (ignored; extracted from endpoint url)", input_type.arg_name, input_type.arg_type);
-                                            }
-                                            // hook.path_params.push(HookPathParam {
-                                            //     hook_arg_name: input_type.arg_name,
-                                            //     hook_arg_type: input_type.arg_type,
-                                            // });
-                                        }
-                                        ParamType::QUERY => {
-                                            if state.is_debug {
-                                                println!(
-                                                    "\t> ParamType::QUERY '{}: {}'",
-                                                    input_type.arg_name, input_type.arg_type
-                                                );
-                                            }
-
-                                            hook.query_params.push(HookQueryParam {
-                                                hook_arg_name: input_type.arg_name,
-                                                hook_arg_type: input_type.arg_type,
-                                            });
-                                        }
-                                        ParamType::UNKNOWN => {
-                                            // TODO: param type is unknown
-                                        }
-                                    }
-
-                                    // state.types.push_str(&format!("{}", input_type.ty));
-                                    if arg_index < num_args {
-                                        arg_index += 1;
-                                        // state.types.push_str(", ");
-                                    }
-                                }
-                                _ => {}
-                            },
-                            _ => {}
-                        }
-                    }
-                    state.types.push('\n');
-                    state.types.push_str(&hook.to_string());
-                    state.hooks.push(hook);
-                    state.types.push('\n');
+                    println!(
+                        "Encountered #[get|post|put|delete] struct: {}",
+                        exported_fn.sig.ident
+                    );
+                } else {
+                    println!("Encountered non-query struct: {}", exported_fn.sig.ident);
                 }
             }
-            _ => {}
+
+            if has_qsync_attribute {
+                let qsync_props = qsync_props.unwrap();
+                let mut hook = Hook {
+                    uses_auth: false,
+                    endpoint_url: "".to_string(),
+                    endpoint_verb: HttpVerb::Unknown,
+                    is_mutation: qsync_props.is_mutation,
+                    return_type: qsync_props.return_type,
+                    hook_name: generate_hook_name(&input_path, exported_fn.sig.ident.to_string()),
+                    query_key_base: generate_query_key_base(&input_path),
+                    body_params: vec![],
+                    path_params: vec![],
+                    query_params: vec![],
+                };
+
+                extract_endpoint_information(&input_path, &exported_fn.attrs, &mut hook);
+                extract_path_params_from_hook_endpoint_url(&mut hook);
+
+                let mut arg_index = 0;
+                let num_args = exported_fn.sig.inputs.len() - 1;
+                for arg in exported_fn.sig.inputs {
+                    if let FnArg::Typed(typed_arg) = arg.clone() {
+                        if let Type::Path(type_path) = *typed_arg.clone().ty {
+                            let input_type =
+                                get_api_fn_input_param_type(typed_arg.clone(), type_path);
+
+                            match input_type.param_type {
+                                ParamType::Auth => {
+                                    if state.is_debug {
+                                        println!("\t> ParamType::AUTH",);
+                                    }
+                                    hook.uses_auth = true;
+                                }
+                                ParamType::Body => {
+                                    if state.is_debug {
+                                        println!(
+                                            "\t> ParamType::BODY '{}: {}'",
+                                            input_type.arg_name, input_type.arg_type
+                                        );
+                                    }
+                                    hook.body_params.push(HookBodyParam {
+                                        hook_arg_name: input_type.arg_name,
+                                        hook_arg_type: input_type.arg_type,
+                                    });
+                                }
+                                ParamType::Path => {
+                                    if state.is_debug {
+                                        println!("\t> ParamType::PATH '{}: {}', (ignored; extracted from endpoint url)", input_type.arg_name, input_type.arg_type);
+                                    }
+                                    // hook.path_params.push(HookPathParam {
+                                    //     hook_arg_name: input_type.arg_name,
+                                    //     hook_arg_type: input_type.arg_type,
+                                    // });
+                                }
+                                ParamType::Query => {
+                                    if state.is_debug {
+                                        println!(
+                                            "\t> ParamType::QUERY '{}: {}'",
+                                            input_type.arg_name, input_type.arg_type
+                                        );
+                                    }
+
+                                    hook.query_params.push(HookQueryParam {
+                                        hook_arg_name: input_type.arg_name,
+                                        hook_arg_type: input_type.arg_type,
+                                    });
+                                }
+                                ParamType::Unknown => {
+                                    // TODO: param type is unknown
+                                }
+                            }
+
+                            // state.types.push_str(&format!("{}", input_type.ty));
+                            if arg_index < num_args {
+                                arg_index += 1;
+                                // state.types.push_str(", ");
+                            }
+                        }
+                    }
+                }
+                state.types.push('\n');
+                state.types.push_str(&hook.to_string());
+                state.hooks.push(hook);
+                state.types.push('\n');
+            }
         }
     }
 }
@@ -496,7 +459,7 @@ pub fn process(input_paths: Vec<PathBuf>, output_path: PathBuf, is_debug: bool) 
         types: String::new(),
         hooks: vec![],
         unprocessed_files: Vec::<PathBuf>::new(),
-        is_debug: is_debug,
+        is_debug,
     };
 
     state.types.push_str(
@@ -635,8 +598,8 @@ pub fn process(input_paths: Vec<PathBuf>, output_path: PathBuf, is_debug: bool) 
             {
                 file_content.push('\n');
                 file_content.push_str(&hook.to_string());
-                added = added + 1;
-                existing = existing - 1;
+                added += 1;
+                existing -= 1;
                 file_content.push('\n');
             }
 
@@ -655,7 +618,7 @@ pub fn process(input_paths: Vec<PathBuf>, output_path: PathBuf, is_debug: bool) 
         }
     }
 
-    if state.unprocessed_files.len() > 0 {
+    if !state.unprocessed_files.is_empty() {
         println!("Could not parse the following files:");
     }
 

--- a/create-rust-app_cli/src/utils/fs.rs
+++ b/create-rust-app_cli/src/utils/fs.rs
@@ -19,14 +19,14 @@ pub fn is_rust_project(directory: &PathBuf) -> Result<bool> {
         .expect("failed to execute `cargo verify-project`")
         .success();
 
-    return Ok(is_verified_rust_project);
+    Ok(is_verified_rust_project)
 }
 
 pub fn get_current_working_directory() -> Result<PathBuf> {
-    return match std::env::current_dir() {
+    match std::env::current_dir() {
         Ok(path) => Ok(path),
         Err(_) => Err(anyhow!("Could not get current working directory.")),
-    };
+    }
 }
 
 pub fn ensure_file(file: &PathBuf, contents: Option<&str>) -> Result<()> {
@@ -41,7 +41,7 @@ pub fn ensure_file(file: &PathBuf, contents: Option<&str>) -> Result<()> {
         std::fs::write(&file, contents.unwrap())?;
     }
 
-    return Ok(());
+    Ok(())
 }
 
 pub fn ensure_directory(directory: &PathBuf, prompt_before_create: bool) -> Result<()> {
@@ -89,7 +89,7 @@ pub fn ensure_directory(directory: &PathBuf, prompt_before_create: bool) -> Resu
         }
     }
 
-    return Ok(());
+    Ok(())
 }
 
 fn read(file_path: &str) -> Result<(PathBuf, String)> {

--- a/create-rust-app_cli/src/utils/logger.rs
+++ b/create-rust-app_cli/src/utils/logger.rs
@@ -1,5 +1,5 @@
-use console::style;
 use crate::BackendDatabase;
+use console::style;
 
 pub fn message(msg: &str) {
     println!("[{}] {}", style("create-rust-app").blue(), msg)
@@ -88,7 +88,7 @@ pub fn project_created_msg(install_config: crate::plugins::InstallConfig) {
 
     // TODO: update dev server to watch rust and frontend files and execute tsync/dsync calls accordingly
     if !is_cargo_watch_installed {
-        message(&format!("• Install cargo-watch (for development)"));
+        message("• Install cargo-watch (for development)");
         message(&format!(
             "  $ {}",
             style("cargo install cargo-watch").cyan()
@@ -96,30 +96,28 @@ pub fn project_created_msg(install_config: crate::plugins::InstallConfig) {
     }
 
     if !is_diesel_cli_installed {
-        message(&format!("• Install diesel (to manage the database)"));
+        message("• Install diesel (to manage the database)");
         message(&format!(
             "  $ {} \"{}\"",
             style("cargo install diesel_cli --no-default-features --features").cyan(),
             match install_config.backend_database {
                 BackendDatabase::Postgres => "postgres",
-                BackendDatabase::Sqlite => "sqlite-bundled"
+                BackendDatabase::Sqlite => "sqlite-bundled",
             }
         ));
     }
 
-    message(&format!("• Begin development!"));
-    message(&format!("  1. Change to your project directory"));
+    message("• Begin development!");
+    message("  1. Change to your project directory");
     message(&format!(
         "     $ {}",
-        style(format!("cd {:#?}", project_dir).to_string()).cyan()
+        style(format!("cd {:#?}", project_dir)).cyan()
     ));
-    message(&format!("  2. Open `.env` and set the DATABASE_URL"));
+    message("  2. Open `.env` and set the DATABASE_URL");
     message(&format!("     $ {}", style("vim .env").cyan()));
-    message(&format!("  3. Setup your database:"));
+    message("  3. Setup your database:");
     message(&format!("     $ {}", style("diesel database reset").cyan()));
-    message(&format!(
-        "  4. Develop! Run the following for continuous compilation:"
-    ));
+    message("  4. Develop! Run the following for continuous compilation:");
     message(&format!("     $ {}", style("cargo fullstack").cyan()));
-    message(&format!("• Enjoy!"));
+    message("• Enjoy!");
 }


### PR DESCRIPTION
Attempts to add documentation to the create-rust-app library that can be parsed by / published to [docs.rs](https://docs.rs/)

even some things marked as "complete" may include TODOs for things I don't understand or don't have the will to document

### Progress

#### library root
- [x] mailer.rs 
- [x] logger.rs 
- [x] lib.rs 

#### database module 
- [x] mod.rs 

#### auth module
- [x] endpoints submodule
- [x] extractors submodule
- [x] mail submodule (Documentation not needed, this is a private submodule)
- [x] permissions submodule
- [x] schema submodule (Documentation not needed)
- [x] controller.rs
- [x] mod.rs
- [ ] user_session.rs 
- [ ] user.rs

### not started, and may not do:
#### dev module
I don't see much point documenting this as the Dev panel still hasn't been implemented
- [ ] endpoints submodule
- [ ] controller.rs
- [ ] mod.rs

#### storage module
I personally have little motivation to document this as it's not a feature I see myself using soon, selfish I know, but I'm busy
- [ ] schema submodule
- [ ] attachment_blob.rs
- [ ] attachment.rs
- [ ] mod.rs
- [ ] schema.rs

#### util module
will probably document, but later
- [ ] actix_web_utils.rs
- [ ] mod.rs
- [ ] net.rs
- [ ] poem_utils.rs
- [ ] template_utils.rs
