### PR TITLE
Library Crate Documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "create-rust-app"
-version = "8.1.0"
+version = "8.1.1"
 dependencies = [
  "actix-files",
  "actix-http",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "create-rust-app_cli"
-version = "8.1.0"
+version = "8.1.1"
 dependencies = [
  "Inflector",
  "anyhow",

--- a/create-rust-app/src/auth/controller.rs
+++ b/create-rust-app/src/auth/controller.rs
@@ -28,7 +28,7 @@ type StatusCode = i32;
 type Message = &'static str;
 
 #[derive(Deserialize, Serialize)]
-/// Rust struct representing the Json body of 
+/// Rust struct representing the Json body of
 /// POST requests to the .../login endpoint
 pub struct LoginInput {
     email: String,
@@ -46,7 +46,7 @@ pub struct RefreshTokenClaims {
 }
 
 #[derive(Serialize, Deserialize)]
-/// Rust struct representing the Json body of 
+/// Rust struct representing the Json body of
 /// POST requests to the .../register endpoint
 pub struct RegisterInput {
     email: String,
@@ -62,14 +62,14 @@ pub struct RegistrationClaims {
 }
 
 #[derive(Serialize, Deserialize)]
-/// Rust struct representing the Json body of 
+/// Rust struct representing the Json body of
 /// GET requests to the .../activate endpoint
 pub struct ActivationInput {
     activation_token: String,
 }
 
 #[derive(Serialize, Deserialize)]
-/// Rust struct representing the Json body of 
+/// Rust struct representing the Json body of
 /// POST requests to the /forgot endpoint
 pub struct ForgotInput {
     email: String,
@@ -84,7 +84,7 @@ pub struct ResetTokenClaims {
 }
 
 #[derive(Serialize, Deserialize)]
-/// Rust struct representing the Json body of 
+/// Rust struct representing the Json body of
 /// POST requests to the /change endpoint
 pub struct ChangeInput {
     old_password: String,
@@ -92,7 +92,7 @@ pub struct ChangeInput {
 }
 
 #[derive(Serialize, Deserialize)]
-/// Rust struct representing the Json body of 
+/// Rust struct representing the Json body of
 /// POST requests to the /reset endpoint
 pub struct ResetInput {
     reset_token: String,
@@ -100,14 +100,14 @@ pub struct ResetInput {
 }
 
 /// /sessions
-/// 
-/// queries [`db`](`Database`) for all sessions owned by the User 
+///
+/// queries [`db`](`Database`) for all sessions owned by the User
 /// associated with [`auth`](`Auth`)
-/// 
+///
 /// breaks up the results of that query as defined by [`info`](`PaginationParams`)
-/// 
-/// 
-/// # Returns [`Result`] 
+///
+///
+/// # Returns [`Result`]
 /// - Ok([`UserSessionResponse`])
 ///     - the results of the query paginated according to [`info`](`PaginationParams`)
 /// - Err([`StatusCode`], [`Message`])
@@ -161,11 +161,11 @@ pub fn get_sessions(
 }
 
 /// /sessions/{id}
-/// 
+///
 /// deletes the entry in the `user_session` with the specified [`item_id`](`ID`) from
 /// [`db`](`Database`) if it's owned by the User associated with [`auth`](`Auth`)
-/// 
-/// # Returns [`Result`] 
+///
+/// # Returns [`Result`]
 /// - Ok(`()`)
 /// - Err([`StatusCode`], [`Message`])
 pub fn destroy_session(
@@ -195,11 +195,11 @@ pub fn destroy_session(
 }
 
 /// /sessions
-/// 
+///
 /// destroys all entries in the `user_session` table in [`db`](`Database`) owned
 /// by the User associated with [`auth`](`Auth`)
-/// 
-/// # Returns [`Result`] 
+///
+/// # Returns [`Result`]
 /// - Ok(`()`)
 /// - Err([`StatusCode`], [`Message`])
 pub fn destroy_sessions(db: &Database, auth: &Auth) -> Result<(), (StatusCode, Message)> {
@@ -216,12 +216,12 @@ type AccessToken = String;
 type RefreshToken = String;
 
 /// /login
-/// 
-/// creates a user session for the user associated with [`item`](`LoginInput`) 
+///
+/// creates a user session for the user associated with [`item`](`LoginInput`)
 /// in the request body (have the `content-type` header set to `application/json` and content that can be deserialized into [`LoginInput`])
-/// 
+///
 /// # Returns [`Result`]
-/// - Ok([`AccessToken`], [`RefreshToken`]) 
+/// - Ok([`AccessToken`], [`RefreshToken`])
 ///     - an access token that should be sent to the user in the response body,
 ///     - a reset token that should be sent as a secure, http-only, and same_site=strict cookie.
 /// - Err([`StatusCode`], [`Message`])
@@ -325,8 +325,8 @@ pub fn login(
 
 /// /logout
 /// If this is successful, delete the cookie storing the refresh token
-/// 
-/// # Returns [`Result`] 
+///
+/// # Returns [`Result`]
 /// - Ok(`()`)
 /// - Err([`StatusCode`], [`Message`])
 pub fn logout(db: &Database, refresh_token: Option<&'_ str>) -> Result<(), (StatusCode, Message)> {
@@ -356,11 +356,11 @@ pub fn logout(db: &Database, refresh_token: Option<&'_ str>) -> Result<(), (Stat
 }
 
 /// /refresh
-/// 
+///
 /// refreshes the user session associated with the clients refresh_token cookie
-/// 
+///
 /// # Returns [`Result`]
-/// - Ok([`AccessToken`], [`RefreshToken`]) 
+/// - Ok([`AccessToken`], [`RefreshToken`])
 ///     - an access token that should be sent to the user in the response body,
 ///     - a reset token that should be sent as a secure, http-only, and same_site=strict cookie.
 /// - Err([`StatusCode`], [`Message`])
@@ -463,14 +463,14 @@ pub fn refresh(
 }
 
 /// /register
-/// 
+///
 /// creates a new User with the information in [`item`](`RegisterInput`)
-/// 
+///
 /// sends an email, using [`mailer`](`Mailer`), to the email address in [`item`](`RegisterInput`)
 /// that contains a unique link that allows the recipient to activate the account associated with
 /// that email address
-/// 
-/// # Returns [`Result`] 
+///
+/// # Returns [`Result`]
 /// - Ok(`()`)
 /// - Err([`StatusCode`], [`Message`])
 pub fn register(
@@ -530,10 +530,10 @@ pub fn register(
 }
 
 /// /activate
-/// 
-/// activates the account associated with the token in [`item`](`ActivationInput`) 
-/// 
-/// # Returns [`Result`] 
+///
+/// activates the account associated with the token in [`item`](`ActivationInput`)
+///
+/// # Returns [`Result`]
 /// - Ok(`()`)
 /// - Err([`StatusCode`], [`Message`])
 pub fn activate(
@@ -597,13 +597,13 @@ pub fn activate(
 /// /forgot
 /// sends an email to the email in the ['ForgotInput'] Json in the request body
 /// that will allow the user associated with that email to change their password
-/// 
+///
 /// sends an email, using [`mailer`](`Mailer`), to the email address in [`item`](`RegisterInput`)
-/// that contains a unique link that allows the recipient to reset the password 
+/// that contains a unique link that allows the recipient to reset the password
 /// of the account associated with that email address (or create a new account if there is
 /// no accound accosiated with the email address)
-/// 
-/// # Returns [`Result`] 
+///
+/// # Returns [`Result`]
 /// - Ok(`()`)
 /// - Err([`StatusCode`], [`Message`])
 pub fn forgot_password(
@@ -649,11 +649,11 @@ pub fn forgot_password(
 }
 
 /// /change
-/// 
+///
 /// change the password of the User associated with [`auth`](`Auth`)
 /// from [`item.old_password`](`ChangeInput`) to [`item.new_password`](`ChangeInput`)
-/// 
-/// # Returns [`Result`] 
+///
+/// # Returns [`Result`]
 /// - Ok(`()`)
 /// - Err([`StatusCode`], [`Message`])
 pub fn change_password(
@@ -713,17 +713,17 @@ pub fn change_password(
 }
 
 /// /check
-/// 
+///
 /// just a lifeline function, clients can post to this endpoint to check
 /// if the auth service is running
 pub fn check(_: &Auth) {}
 
 /// reset
-/// 
+///
 /// changes the password of the user associated with [`item.reset_token`](`ResetInput`)
 /// to [`item.new_password`](`ResetInput`)
-/// 
-/// # Returns [`Result`] 
+///
+/// # Returns [`Result`]
 /// - Ok(`()`)
 /// - Err([`StatusCode`], [`Message`])
 pub fn reset_password(

--- a/create-rust-app/src/auth/controller.rs
+++ b/create-rust-app/src/auth/controller.rs
@@ -28,6 +28,8 @@ type StatusCode = i32;
 type Message = &'static str;
 
 #[derive(Deserialize, Serialize)]
+/// Rust struct representing the Json body of 
+/// POST requests to the .../login endpoint
 pub struct LoginInput {
     email: String,
     password: String,
@@ -36,6 +38,7 @@ pub struct LoginInput {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+/// TODO: documentation
 pub struct RefreshTokenClaims {
     exp: usize,
     sub: ID,
@@ -43,12 +46,15 @@ pub struct RefreshTokenClaims {
 }
 
 #[derive(Serialize, Deserialize)]
+/// Rust struct representing the Json body of 
+/// POST requests to the .../register endpoint
 pub struct RegisterInput {
     email: String,
     password: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+/// TODO: documentation
 pub struct RegistrationClaims {
     exp: usize,
     sub: ID,
@@ -56,16 +62,21 @@ pub struct RegistrationClaims {
 }
 
 #[derive(Serialize, Deserialize)]
+/// Rust struct representing the Json body of 
+/// GET requests to the .../activate endpoint
 pub struct ActivationInput {
     activation_token: String,
 }
 
 #[derive(Serialize, Deserialize)]
+/// Rust struct representing the Json body of 
+/// POST requests to the /forgot endpoint
 pub struct ForgotInput {
     email: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+/// TODO: documentation
 pub struct ResetTokenClaims {
     exp: usize,
     sub: ID,
@@ -73,18 +84,33 @@ pub struct ResetTokenClaims {
 }
 
 #[derive(Serialize, Deserialize)]
+/// Rust struct representing the Json body of 
+/// POST requests to the /change endpoint
 pub struct ChangeInput {
     old_password: String,
     new_password: String,
 }
 
 #[derive(Serialize, Deserialize)]
+/// Rust struct representing the Json body of 
+/// POST requests to the /reset endpoint
 pub struct ResetInput {
     reset_token: String,
     new_password: String,
 }
 
 /// /sessions
+/// 
+/// queries [`db`](`Database`) for all sessions owned by the User 
+/// associated with [`auth`](`Auth`)
+/// 
+/// breaks up the results of that query as defined by [`info`](`PaginationParams`)
+/// 
+/// 
+/// # Returns [`Result`] 
+/// - Ok([`UserSessionResponse`])
+///     - the results of the query paginated according to [`info`](`PaginationParams`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn get_sessions(
     db: &Database,
     auth: &Auth,
@@ -135,6 +161,13 @@ pub fn get_sessions(
 }
 
 /// /sessions/{id}
+/// 
+/// deletes the entry in the `user_session` with the specified [`item_id`](`ID`) from
+/// [`db`](`Database`) if it's owned by the User associated with [`auth`](`Auth`)
+/// 
+/// # Returns [`Result`] 
+/// - Ok(`()`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn destroy_session(
     db: &Database,
     auth: &Auth,
@@ -162,6 +195,13 @@ pub fn destroy_session(
 }
 
 /// /sessions
+/// 
+/// destroys all entries in the `user_session` table in [`db`](`Database`) owned
+/// by the User associated with [`auth`](`Auth`)
+/// 
+/// # Returns [`Result`] 
+/// - Ok(`()`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn destroy_sessions(db: &Database, auth: &Auth) -> Result<(), (StatusCode, Message)> {
     let mut db = db.pool.get().unwrap();
 
@@ -176,9 +216,15 @@ type AccessToken = String;
 type RefreshToken = String;
 
 /// /login
-/// Returns a tuple;
-/// - the access token should be sent to the user in the body, and,
-/// - the reset token should be sent as a secure, http-only, and same_site=strict cookie.
+/// 
+/// creates a user session for the user associated with [`item`](`LoginInput`) 
+/// in the request body (have the `content-type` header set to `application/json` and content that can be deserialized into [`LoginInput`])
+/// 
+/// # Returns [`Result`]
+/// - Ok([`AccessToken`], [`RefreshToken`]) 
+///     - an access token that should be sent to the user in the response body,
+///     - a reset token that should be sent as a secure, http-only, and same_site=strict cookie.
+/// - Err([`StatusCode`], [`Message`])
 pub fn login(
     db: &Database,
     item: &LoginInput,
@@ -279,6 +325,10 @@ pub fn login(
 
 /// /logout
 /// If this is successful, delete the cookie storing the refresh token
+/// 
+/// # Returns [`Result`] 
+/// - Ok(`()`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn logout(db: &Database, refresh_token: Option<&'_ str>) -> Result<(), (StatusCode, Message)> {
     let mut db = db.pool.get().unwrap();
 
@@ -306,9 +356,14 @@ pub fn logout(db: &Database, refresh_token: Option<&'_ str>) -> Result<(), (Stat
 }
 
 /// /refresh
-/// Returns a tuple;
-/// - the access token should be sent to the user in the body, and,
-/// - the reset token should be sent as a secure, http-only, and same_site=strict cookie.
+/// 
+/// refreshes the user session associated with the clients refresh_token cookie
+/// 
+/// # Returns [`Result`]
+/// - Ok([`AccessToken`], [`RefreshToken`]) 
+///     - an access token that should be sent to the user in the response body,
+///     - a reset token that should be sent as a secure, http-only, and same_site=strict cookie.
+/// - Err([`StatusCode`], [`Message`])
 pub fn refresh(
     db: &Database,
     refresh_token_str: Option<&'_ str>,
@@ -408,6 +463,16 @@ pub fn refresh(
 }
 
 /// /register
+/// 
+/// creates a new User with the information in [`item`](`RegisterInput`)
+/// 
+/// sends an email, using [`mailer`](`Mailer`), to the email address in [`item`](`RegisterInput`)
+/// that contains a unique link that allows the recipient to activate the account associated with
+/// that email address
+/// 
+/// # Returns [`Result`] 
+/// - Ok(`()`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn register(
     db: &Database,
     item: &RegisterInput,
@@ -465,6 +530,12 @@ pub fn register(
 }
 
 /// /activate
+/// 
+/// activates the account associated with the token in [`item`](`ActivationInput`) 
+/// 
+/// # Returns [`Result`] 
+/// - Ok(`()`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn activate(
     db: &Database,
     item: &ActivationInput,
@@ -524,6 +595,17 @@ pub fn activate(
 }
 
 /// /forgot
+/// sends an email to the email in the ['ForgotInput'] Json in the request body
+/// that will allow the user associated with that email to change their password
+/// 
+/// sends an email, using [`mailer`](`Mailer`), to the email address in [`item`](`RegisterInput`)
+/// that contains a unique link that allows the recipient to reset the password 
+/// of the account associated with that email address (or create a new account if there is
+/// no accound accosiated with the email address)
+/// 
+/// # Returns [`Result`] 
+/// - Ok(`()`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn forgot_password(
     db: &Database,
     item: &ForgotInput,
@@ -567,6 +649,13 @@ pub fn forgot_password(
 }
 
 /// /change
+/// 
+/// change the password of the User associated with [`auth`](`Auth`)
+/// from [`item.old_password`](`ChangeInput`) to [`item.new_password`](`ChangeInput`)
+/// 
+/// # Returns [`Result`] 
+/// - Ok(`()`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn change_password(
     db: &Database,
     item: &ChangeInput,
@@ -624,9 +713,19 @@ pub fn change_password(
 }
 
 /// /check
+/// 
+/// just a lifeline function, clients can post to this endpoint to check
+/// if the auth service is running
 pub fn check(_: &Auth) {}
 
 /// reset
+/// 
+/// changes the password of the user associated with [`item.reset_token`](`ResetInput`)
+/// to [`item.new_password`](`ResetInput`)
+/// 
+/// # Returns [`Result`] 
+/// - Ok(`()`)
+/// - Err([`StatusCode`], [`Message`])
 pub fn reset_password(
     db: &Database,
     item: &ResetInput,

--- a/create-rust-app/src/auth/endpoints/service_actixweb.rs
+++ b/create-rust-app/src/auth/endpoints/service_actixweb.rs
@@ -20,13 +20,13 @@ use crate::Mailer;
 
 #[get("/sessions")]
 /// handler for GET requests at the .../sessions endpoint,
-/// 
+///
 /// requires auth
-/// 
+///
 /// request should be a query that contains [`PaginationParams`]
-/// 
+///
 /// see [`controller::get_sessions`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -53,12 +53,12 @@ async fn sessions(
 
 #[delete("/sessions/{id}")]
 /// handler for DELETE requests at the .../sessions/{id} endpoint.
-/// 
+///
 /// requires auth
-/// 
+///
 /// see [`controller::destroy_session`]
-/// 
-/// 
+///
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -88,13 +88,13 @@ async fn destroy_session(
 
 #[delete("/sessions")]
 /// handler for DELETE requests at the .../sessions enpoint
-/// 
+///
 /// requires auth
-/// 
+///
 /// deletes all current sessions belonging to the user
-/// 
+///
 /// see [`controller::destroy_sessions`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -117,11 +117,11 @@ async fn destroy_sessions(db: Data<Database>, auth: Auth) -> Result<HttpResponse
 
 #[post("/login")]
 /// handler for POST requests at the .../login endpoint
-/// 
+///
 /// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`LoginInput`]
-/// 
+///
 /// see [`controller::login`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -154,9 +154,9 @@ async fn login(db: Data<Database>, Json(item): Json<LoginInput>) -> Result<HttpR
 
 #[post("/logout")]
 /// handler for POST requests to the .../logout endpount
-/// 
+///
 /// see [`controller::logout']
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -189,9 +189,9 @@ async fn logout(db: Data<Database>, req: HttpRequest) -> Result<HttpResponse, AW
 
 #[post("/refresh")]
 /// handler for POST requests to the .../refresh endpoint
-/// 
+///
 /// see [`controller::refresh`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -227,11 +227,11 @@ async fn refresh(db: Data<Database>, req: HttpRequest) -> Result<HttpResponse, A
 
 #[post("/register")]
 /// handler for POST requests to the .../register endpoint
-/// 
+///
 /// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`RegisterInput`]
-/// 
+///
 /// see [`controller::register`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -257,9 +257,9 @@ async fn register(
 
 #[get("/activate")]
 /// handler for GET requests to the .../activate endpoint
-/// 
+///
 /// see [`controller:: activate`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -287,11 +287,11 @@ async fn activate(
 
 #[post("/forgot")]
 /// handler for POST requests to the .../forgot endpoint
-/// 
+///
 /// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ForgotInput`]
-/// 
+///
 /// see [`controller::forgot_password`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -316,13 +316,13 @@ async fn forgot_password(
 
 #[post("/change")]
 /// handler for POST requests to the .../change endpoint
-/// 
+///
 /// requires auth
-/// 
+///
 /// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ChangeInput`]
-/// 
+///
 /// see [`controller::change_password`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -354,11 +354,11 @@ async fn change_password(
 
 #[post("/check")]
 /// handler for POST requests to the .../check endpoint
-/// 
+///
 /// requires auth, but doesn't match it to a user
-/// 
+///
 /// see [`controller::check`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -370,11 +370,11 @@ async fn check(auth: Auth) -> HttpResponse {
 
 #[post("/reset")]
 /// handler for POST requests to the .../reset endpoint
-/// 
+///
 /// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ResetInput`]
-/// 
+///
 /// see [`controller::reset_password`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|

--- a/create-rust-app/src/auth/endpoints/service_actixweb.rs
+++ b/create-rust-app/src/auth/endpoints/service_actixweb.rs
@@ -19,6 +19,20 @@ use crate::Database;
 use crate::Mailer;
 
 #[get("/sessions")]
+/// handler for GET requests at the .../sessions endpoint,
+/// 
+/// requires auth
+/// 
+/// request should be a query that contains [`PaginationParams`]
+/// 
+/// see [`controller::get_sessions`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | [`UserSessionResponse`](`crate::auth::UserSessionResponse`) deserialized into a Json payload
+/// | 500 | Json payload : {"message": "Could not fetch sessions."}
+/// TODO: document the rest of the possible StatusCodes
 async fn sessions(
     db: Data<Database>,
     auth: Auth,
@@ -38,6 +52,21 @@ async fn sessions(
 }
 
 #[delete("/sessions/{id}")]
+/// handler for DELETE requests at the .../sessions/{id} endpoint.
+/// 
+/// requires auth
+/// 
+/// see [`controller::destroy_session`]
+/// 
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Deleted."}
+/// | 404 | Json payload : {"message": "Session not found."}
+/// | 500 | Json payload : {"message": "Internal error."}
+/// | 500 | Json payload : {"message": "Could not delete session.`}
+/// TODO: document the rest of the possible StatusCodes
 async fn destroy_session(
     db: Data<Database>,
     item_id: Path<ID>,
@@ -58,6 +87,20 @@ async fn destroy_session(
 }
 
 #[delete("/sessions")]
+/// handler for DELETE requests at the .../sessions enpoint
+/// 
+/// requires auth
+/// 
+/// deletes all current sessions belonging to the user
+/// 
+/// see [`controller::destroy_sessions`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Deleted."}
+/// | 500 | Json payload : {"message": "Could not delete sessions."}
+/// TODO: document the rest of the possible StatusCodes
 async fn destroy_sessions(db: Data<Database>, auth: Auth) -> Result<HttpResponse, AWError> {
     let result = web::block(move || controller::destroy_sessions(&db, &auth)).await?;
 
@@ -73,6 +116,22 @@ async fn destroy_sessions(db: Data<Database>, auth: Auth) -> Result<HttpResponse
 }
 
 #[post("/login")]
+/// handler for POST requests at the .../login endpoint
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`LoginInput`]
+/// 
+/// see [`controller::login`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload with an "assess_token" field containing a JWT associated with the user
+/// | 400 | Json payload : {"message": "'device' cannot be longer than 256 characters."}
+/// | 400 | Json payload : {"message": "Account has not been activated."}
+/// | 401 | Json payload : {"message": "Invalid credentials."}
+/// | 500 | Json payload : {"message": "An internal server error occurred."}
+/// | 500 | Json payload : {"message": "Could not create a session."}
+/// TODO: document the rest of the possible StatusCodes
 async fn login(db: Data<Database>, Json(item): Json<LoginInput>) -> Result<HttpResponse, AWError> {
     let result = web::block(move || controller::login(&db, &item)).await?;
 
@@ -94,6 +153,17 @@ async fn login(db: Data<Database>, Json(item): Json<LoginInput>) -> Result<HttpR
 }
 
 #[post("/logout")]
+/// handler for POST requests to the .../logout endpount
+/// 
+/// see [`controller::logout']
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | command to delete the "refresh_token" cookie
+/// | 401 | Json payload : {"message": "Invalid session."}
+/// | 401 | Json payload : {"message": "Could not delete session."}
+/// TODO: document the rest of the possible StatusCodes
 async fn logout(db: Data<Database>, req: HttpRequest) -> Result<HttpResponse, AWError> {
     let refresh_token = req
         .cookie(COOKIE_NAME)
@@ -118,6 +188,17 @@ async fn logout(db: Data<Database>, req: HttpRequest) -> Result<HttpResponse, AW
 }
 
 #[post("/refresh")]
+/// handler for POST requests to the .../refresh endpoint
+/// 
+/// see [`controller::refresh`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload with an "assess_token" field containing a JWT associated with the user
+/// | 401 | Json payload : {"message": "Invalid session."}
+/// | 401 | Json payload : {"message": "Invalid token."}
+/// TODO: document the rest of the possible StatusCodes
 async fn refresh(db: Data<Database>, req: HttpRequest) -> Result<HttpResponse, AWError> {
     let refresh_token = req
         .cookie(COOKIE_NAME)
@@ -145,6 +226,18 @@ async fn refresh(db: Data<Database>, req: HttpRequest) -> Result<HttpResponse, A
 }
 
 #[post("/register")]
+/// handler for POST requests to the .../register endpoint
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`RegisterInput`]
+/// 
+/// see [`controller::register`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Registered! Check your email to activate your account."}
+/// | 400 | Json payload : {"message": "Already registered."}
+/// TODO: document the rest of the possible StatusCodes
 async fn register(
     db: Data<Database>,
     Json(item): Json<RegisterInput>,
@@ -163,6 +256,19 @@ async fn register(
 }
 
 #[get("/activate")]
+/// handler for GET requests to the .../activate endpoint
+/// 
+/// see [`controller:: activate`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Activated."}
+/// | 200 | Json payload : {"message": "Already activated."}
+/// | 400 | Json payload : {"message": "Invalid token."}
+/// | 401 | Json payload : {"message": "Invalid token"}
+/// | 500 | Json payload : {"message": "Could not activate user. "}
+/// TODO: document the rest of the possible StatusCodes
 async fn activate(
     db: Data<Database>,
     Query(item): Query<ActivationInput>,
@@ -180,6 +286,17 @@ async fn activate(
 }
 
 #[post("/forgot")]
+/// handler for POST requests to the .../forgot endpoint
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ForgotInput`]
+/// 
+/// see [`controller::forgot_password`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Please check your email."}
+/// TODO: document the rest of the possible StatusCodes
 async fn forgot_password(
     db: Data<Database>,
     Json(item): Json<ForgotInput>,
@@ -198,6 +315,25 @@ async fn forgot_password(
 }
 
 #[post("/change")]
+/// handler for POST requests to the .../change endpoint
+/// 
+/// requires auth
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ChangeInput`]
+/// 
+/// see [`controller::change_password`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Password changed."}
+/// | 400 | Json payload : {"message": "Missing password."}
+/// | 400 | Json payload : {"message": "The new password must be different."}
+/// | 400 | Json payload : {"message": "Account has not been activated."}
+/// | 400 | Json payload : {"message": "Invalid credentials."}
+/// | 500 | Json payload : {"message": "Could not find user."}
+/// | 500 | Json payload : {"message": "Could not update password."}
+/// TODO: document the rest of the possible StatusCodes
 async fn change_password(
     db: Data<Database>,
     Json(item): Json<ChangeInput>,
@@ -217,12 +353,37 @@ async fn change_password(
 }
 
 #[post("/check")]
+/// handler for POST requests to the .../check endpoint
+/// 
+/// requires auth, but doesn't match it to a user
+/// 
+/// see [`controller::check`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | ()
 async fn check(auth: Auth) -> HttpResponse {
     controller::check(&auth);
     HttpResponse::Ok().finish()
 }
 
 #[post("/reset")]
+/// handler for POST requests to the .../reset endpoint
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ResetInput`]
+/// 
+/// see [`controller::reset_password`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Password changed."}
+/// | 400 | Json payload : {"message": "Invalid token."}
+/// | 400 | Json payload : {"message": "Account has not been activated."}
+/// | 400 | Json payload : {"message": "The new password must be different."}
+/// | 401 | Json payload : {"message": "Invalid token."}
+/// | 500 | Json payload : {"message": "Could not update password."}
 async fn reset_password(
     db: Data<Database>,
     Json(item): Json<ResetInput>,
@@ -240,6 +401,7 @@ async fn reset_password(
     }
 }
 
+/// returns the endpoints for the Auth service
 pub fn endpoints(scope: actix_web::Scope) -> actix_web::Scope {
     return scope
         .service(sessions)

--- a/create-rust-app/src/auth/endpoints/service_poem.rs
+++ b/create-rust-app/src/auth/endpoints/service_poem.rs
@@ -25,13 +25,13 @@ fn error_response(status_code: i32, message: &'static str) -> Error {
 
 #[handler]
 /// handler for GET requests at the .../sessions endpoint,
-/// 
+///
 /// requires auth
-/// 
+///
 /// request should be a query that contains [`PaginationParams`]
-/// 
+///
 /// see [`controller::get_sessions`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -53,13 +53,13 @@ async fn sessions(
 
 #[handler]
 /// handler for DELETE requests at the .../sessions enpoint
-/// 
+///
 /// requires auth
-/// 
+///
 /// deletes all current sessions belonging to the user
-/// 
+///
 /// see [`controller::destroy_sessions`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -77,12 +77,12 @@ async fn destroy_sessions(db: Data<&Database>, auth: Auth) -> Result<impl IntoRe
 
 #[handler]
 /// handler for DELETE requests at the .../sessions/{id} endpoint.
-/// 
+///
 /// requires auth
-/// 
+///
 /// see [`controller::destroy_session`]
-/// 
-/// 
+///
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -106,11 +106,11 @@ async fn destroy_session(
 
 #[handler]
 /// handler for POST requests at the .../login endpoint
-/// 
+///
 /// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`LoginInput`]
-/// 
+///
 /// see [`controller::login`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -147,9 +147,9 @@ async fn login(
 
 #[handler]
 /// handler for POST requests to the .../logout endpount
-/// 
+///
 /// see [`controller::logout']
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -179,9 +179,9 @@ async fn logout(db: Data<&Database>, cookie_jar: &CookieJar) -> Result<impl Into
 
 #[handler]
 /// handler for POST requests to the .../refresh endpoint
-/// 
+///
 /// see [`controller::refresh`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -214,11 +214,11 @@ async fn refresh(db: Data<&Database>, cookie_jar: &CookieJar) -> Result<impl Int
 
 #[handler]
 /// handler for POST requests to the .../register endpoint
-/// 
+///
 /// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`RegisterInput`]
-/// 
+///
 /// see [`controller::register`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -242,9 +242,9 @@ async fn register(
 
 #[handler]
 /// handler for GET requests to the .../activate endpoint
-/// 
+///
 /// see [`controller:: activate`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -272,11 +272,11 @@ async fn activate(
 
 #[handler]
 /// handler for POST requests to the .../forgot endpoint
-/// 
+///
 /// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ForgotInput`]
-/// 
+///
 /// see [`controller::forgot_password`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -299,13 +299,13 @@ async fn forgot_password(
 
 #[handler]
 /// handler for POST requests to the .../change endpoint
-/// 
+///
 /// requires auth
-/// 
+///
 /// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ChangeInput`]
-/// 
+///
 /// see [`controller::change_password`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -335,11 +335,11 @@ async fn change_password(
 
 #[handler]
 /// handler for POST requests to the .../reset endpoint
-/// 
+///
 /// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ResetInput`]
-/// 
+///
 /// see [`controller::reset_password`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|
@@ -366,11 +366,11 @@ async fn reset_password(
 
 #[handler]
 /// handler for POST requests to the .../check endpoint
-/// 
+///
 /// requires auth, but doesn't match it to a user
-/// 
+///
 /// see [`controller::check`]
-/// 
+///
 /// # Responses
 /// | StatusCode | content |
 /// |:------------|---------|

--- a/create-rust-app/src/auth/endpoints/service_poem.rs
+++ b/create-rust-app/src/auth/endpoints/service_poem.rs
@@ -24,6 +24,20 @@ fn error_response(status_code: i32, message: &'static str) -> Error {
 }
 
 #[handler]
+/// handler for GET requests at the .../sessions endpoint,
+/// 
+/// requires auth
+/// 
+/// request should be a query that contains [`PaginationParams`]
+/// 
+/// see [`controller::get_sessions`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | [`UserSessionResponse`](`crate::auth::UserSessionResponse`) deserialized into a Json payload
+/// | 500 | Json payload : {"message": "Could not fetch sessions."}
+/// TODO: document the rest of the possible StatusCodes
 async fn sessions(
     db: Data<&Database>,
     auth: Auth,
@@ -38,6 +52,20 @@ async fn sessions(
 }
 
 #[handler]
+/// handler for DELETE requests at the .../sessions enpoint
+/// 
+/// requires auth
+/// 
+/// deletes all current sessions belonging to the user
+/// 
+/// see [`controller::destroy_sessions`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Deleted."}
+/// | 500 | Json payload : {"message": "Could not delete sessions."}
+/// TODO: document the rest of the possible StatusCodes
 async fn destroy_sessions(db: Data<&Database>, auth: Auth) -> Result<impl IntoResponse> {
     let result = controller::destroy_sessions(db.0, &auth);
 
@@ -48,6 +76,21 @@ async fn destroy_sessions(db: Data<&Database>, auth: Auth) -> Result<impl IntoRe
 }
 
 #[handler]
+/// handler for DELETE requests at the .../sessions/{id} endpoint.
+/// 
+/// requires auth
+/// 
+/// see [`controller::destroy_session`]
+/// 
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Deleted."}
+/// | 404 | Json payload : {"message": "Session not found."}
+/// | 500 | Json payload : {"message": "Internal error."}
+/// | 500 | Json payload : {"message": "Could not delete session.`}
+/// TODO: document the rest of the possible StatusCodes
 async fn destroy_session(
     db: Data<&Database>,
     Path(item_id): Path<ID>,
@@ -62,6 +105,22 @@ async fn destroy_session(
 }
 
 #[handler]
+/// handler for POST requests at the .../login endpoint
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`LoginInput`]
+/// 
+/// see [`controller::login`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload with an "assess_token" field containing a JWT associated with the user
+/// | 400 | Json payload : {"message": "'device' cannot be longer than 256 characters."}
+/// | 400 | Json payload : {"message": "Account has not been activated."}
+/// | 401 | Json payload : {"message": "Invalid credentials."}
+/// | 500 | Json payload : {"message": "An internal server error occurred."}
+/// | 500 | Json payload : {"message": "Could not create a session."}
+/// TODO: document the rest of the possible StatusCodes
 async fn login(
     db: Data<&Database>,
     Json(item): Json<LoginInput>,
@@ -87,6 +146,17 @@ async fn login(
 }
 
 #[handler]
+/// handler for POST requests to the .../logout endpount
+/// 
+/// see [`controller::logout']
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | command to delete the "refresh_token" cookie
+/// | 401 | Json payload : {"message": "Invalid session."}
+/// | 401 | Json payload : {"message": "Could not delete session."}
+/// TODO: document the rest of the possible StatusCodes
 async fn logout(db: Data<&Database>, cookie_jar: &CookieJar) -> Result<impl IntoResponse> {
     let refresh_token = cookie_jar
         .get(COOKIE_NAME)
@@ -108,6 +178,17 @@ async fn logout(db: Data<&Database>, cookie_jar: &CookieJar) -> Result<impl Into
 }
 
 #[handler]
+/// handler for POST requests to the .../refresh endpoint
+/// 
+/// see [`controller::refresh`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload with an "assess_token" field containing a JWT associated with the user
+/// | 401 | Json payload : {"message": "Invalid session."}
+/// | 401 | Json payload : {"message": "Invalid token."}
+/// TODO: document the rest of the possible StatusCodes
 async fn refresh(db: Data<&Database>, cookie_jar: &CookieJar) -> Result<impl IntoResponse> {
     let refresh_token = cookie_jar
         .get(COOKIE_NAME)
@@ -132,6 +213,18 @@ async fn refresh(db: Data<&Database>, cookie_jar: &CookieJar) -> Result<impl Int
 }
 
 #[handler]
+/// handler for POST requests to the .../register endpoint
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`RegisterInput`]
+/// 
+/// see [`controller::register`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Registered! Check your email to activate your account."}
+/// | 400 | Json payload : {"message": "Already registered."}
+/// TODO: document the rest of the possible StatusCodes
 async fn register(
     db: Data<&Database>,
     Json(item): Json<RegisterInput>,
@@ -148,6 +241,19 @@ async fn register(
 }
 
 #[handler]
+/// handler for GET requests to the .../activate endpoint
+/// 
+/// see [`controller:: activate`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Activated."}
+/// | 200 | Json payload : {"message": "Already activated."}
+/// | 400 | Json payload : {"message": "Invalid token."}
+/// | 401 | Json payload : {"message": "Invalid token"}
+/// | 500 | Json payload : {"message": "Could not activate user. "}
+/// TODO: document the rest of the possible StatusCodes
 async fn activate(
     db: Data<&Database>,
     Query(item): Query<ActivationInput>,
@@ -165,6 +271,17 @@ async fn activate(
 }
 
 #[handler]
+/// handler for POST requests to the .../forgot endpoint
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ForgotInput`]
+/// 
+/// see [`controller::forgot_password`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Please check your email."}
+/// TODO: document the rest of the possible StatusCodes
 async fn forgot_password(
     db: Data<&Database>,
     Json(item): Json<ForgotInput>,
@@ -181,6 +298,25 @@ async fn forgot_password(
 }
 
 #[handler]
+/// handler for POST requests to the .../change endpoint
+/// 
+/// requires auth
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ChangeInput`]
+/// 
+/// see [`controller::change_password`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Password changed."}
+/// | 400 | Json payload : {"message": "Missing password."}
+/// | 400 | Json payload : {"message": "The new password must be different."}
+/// | 400 | Json payload : {"message": "Account has not been activated."}
+/// | 400 | Json payload : {"message": "Invalid credentials."}
+/// | 500 | Json payload : {"message": "Could not find user."}
+/// | 500 | Json payload : {"message": "Could not update password."}
+/// TODO: document the rest of the possible StatusCodes
 async fn change_password(
     db: Data<&Database>,
     Json(item): Json<ChangeInput>,
@@ -198,6 +334,21 @@ async fn change_password(
 }
 
 #[handler]
+/// handler for POST requests to the .../reset endpoint
+/// 
+/// request must have the `Content-Type: application/json` header, and a Json payload that can be deserialized into [`ResetInput`]
+/// 
+/// see [`controller::reset_password`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | Json payload : {"message": "Password changed."}
+/// | 400 | Json payload : {"message": "Invalid token."}
+/// | 400 | Json payload : {"message": "Account has not been activated."}
+/// | 400 | Json payload : {"message": "The new password must be different."}
+/// | 401 | Json payload : {"message": "Invalid token."}
+/// | 500 | Json payload : {"message": "Could not update password."}
 async fn reset_password(
     db: Data<&Database>,
     Json(item): Json<ResetInput>,
@@ -214,11 +365,22 @@ async fn reset_password(
 }
 
 #[handler]
+/// handler for POST requests to the .../check endpoint
+/// 
+/// requires auth, but doesn't match it to a user
+/// 
+/// see [`controller::check`]
+/// 
+/// # Responses
+/// | StatusCode | content |
+/// |:------------|---------|
+/// | 200 | ()
 async fn check(auth: Auth) -> Result<impl IntoResponse> {
     controller::check(&auth);
     Ok(Response::builder().status(StatusCode::OK).finish())
 }
 
+/// returns endpoints for the Auth service
 pub fn api() -> Route {
     Route::new()
         .at("/sessions", get(sessions).delete(destroy_sessions))

--- a/create-rust-app/src/auth/extractors/auth_actixweb.rs
+++ b/create-rust-app/src/auth/extractors/auth_actixweb.rs
@@ -15,7 +15,7 @@ use std::iter::FromIterator;
 
 #[derive(Debug, Clone)]
 /// roles and permissions available to a User
-/// 
+///
 /// use to control what users are and are not allowed to do
 pub struct Auth {
     pub user_id: ID,

--- a/create-rust-app/src/auth/extractors/auth_actixweb.rs
+++ b/create-rust-app/src/auth/extractors/auth_actixweb.rs
@@ -43,8 +43,8 @@ impl Auth {
     }
 
     /// does the user with the id [`self.user_id`](`ID`) have the given `role`
-    pub fn has_role(&self, permission: String) -> bool {
-        self.roles.contains(&permission.to_string())
+    pub fn has_role(&self, role: String) -> bool {
+        self.roles.contains(&role.to_string())
     }
 
     /// does the user with the id [`self.user_id`](`ID`) have all of the given `roles`
@@ -70,7 +70,7 @@ impl ResponseError for AuthError {
     fn error_response(&self) -> HttpResponse {
         // HttpResponse::Unauthorized().json(self.reason.as_str())
         // println!("error_response");
-        HttpResponse::build(StatusCode::UNAUTHORIZED).body(
+        HttpResponse::build(self.status_code()).body(
             json!({
               "message": self.reason.as_str()
             })

--- a/create-rust-app/src/auth/extractors/auth_actixweb.rs
+++ b/create-rust-app/src/auth/extractors/auth_actixweb.rs
@@ -14,6 +14,9 @@ use std::collections::HashSet;
 use std::iter::FromIterator;
 
 #[derive(Debug, Clone)]
+/// roles and permissions available to a User
+/// 
+/// use to control what users are and are not allowed to do
 pub struct Auth {
     pub user_id: ID,
     pub roles: HashSet<String>,
@@ -21,6 +24,7 @@ pub struct Auth {
 }
 
 impl Auth {
+    /// does the user with the id [`self.user_id`](`ID`) have the given `permission`
     pub fn has_permission(&self, permission: String) -> bool {
         self.permissions.contains(&Permission {
             permission: permission.to_string(),
@@ -28,22 +32,27 @@ impl Auth {
         })
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have all of the given `perms`
     pub fn has_all_permissions(&self, perms: Vec<String>) -> bool {
         perms.iter().all(|p| self.has_permission(p.to_string()))
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have any of the given `perms`
     pub fn has_any_permission(&self, perms: Vec<String>) -> bool {
         perms.iter().any(|p| self.has_permission(p.to_string()))
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have the given `role`
     pub fn has_role(&self, permission: String) -> bool {
         self.roles.contains(&permission.to_string())
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have all of the given `roles`
     pub fn has_all_roles(&self, roles: Vec<String>) -> bool {
         roles.iter().all(|r| self.has_role(r.to_string()))
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have any of the given `roles`
     pub fn has_any_roles(&self, roles: Vec<String>) -> bool {
         roles.iter().any(|r| self.has_role(r.to_string()))
     }
@@ -51,11 +60,13 @@ impl Auth {
 
 #[derive(Debug, Display, Error)]
 #[display(fmt = "Unauthorized, reason: {}", self.reason)]
+/// custom error type for Authorization related errors
 pub struct AuthError {
     reason: String,
 }
 
 impl ResponseError for AuthError {
+    /// builds an [`HttpResponse`] for [`self`](`AuthError`)
     fn error_response(&self) -> HttpResponse {
         // HttpResponse::Unauthorized().json(self.reason.as_str())
         // println!("error_response");
@@ -67,6 +78,7 @@ impl ResponseError for AuthError {
         )
     }
 
+    /// return the [`StatusCode`] associated with an [`AuthError`]
     fn status_code(&self) -> StatusCode {
         StatusCode::UNAUTHORIZED
     }
@@ -76,6 +88,7 @@ impl FromRequest for Auth {
     type Future = Ready<Result<Self, Self::Error>>;
     type Error = AuthError;
 
+    /// extracts [`Auth`] from the given [`req`](`HttpRequest`)
     fn from_request(req: &HttpRequest, _payload: &mut Payload) -> <Self as FromRequest>::Future {
         let auth_header_opt: Option<&HeaderValue> = req.headers().get("Authorization");
 

--- a/create-rust-app/src/auth/extractors/auth_poem.rs
+++ b/create-rust-app/src/auth/extractors/auth_poem.rs
@@ -12,7 +12,7 @@ use std::iter::FromIterator;
 
 #[derive(Debug, Clone)]
 /// roles and permissions available to a User
-/// 
+///
 /// use to control what users are and are not allowed to do
 pub struct Auth {
     pub user_id: ID,

--- a/create-rust-app/src/auth/extractors/auth_poem.rs
+++ b/create-rust-app/src/auth/extractors/auth_poem.rs
@@ -40,8 +40,8 @@ impl Auth {
     }
 
     /// does the user with the id [`self.user_id`](`ID`) have the given `role`
-    pub fn has_role(&self, permission: String) -> bool {
-        self.roles.contains(&permission.to_string())
+    pub fn has_role(&self, role: String) -> bool {
+        self.roles.contains(&role.to_string())
     }
 
     /// does the user with the id [`self.user_id`](`ID`) have all of the given `roles`

--- a/create-rust-app/src/auth/extractors/auth_poem.rs
+++ b/create-rust-app/src/auth/extractors/auth_poem.rs
@@ -11,6 +11,9 @@ use jsonwebtoken::Validation;
 use std::iter::FromIterator;
 
 #[derive(Debug, Clone)]
+/// roles and permissions available to a User
+/// 
+/// use to control what users are and are not allowed to do
 pub struct Auth {
     pub user_id: ID,
     pub roles: HashSet<String>,
@@ -18,6 +21,7 @@ pub struct Auth {
 }
 
 impl Auth {
+    /// does the user with the id [`self.user_id`](`ID`) have the given `permission`
     pub fn has_permission(&self, permission: String) -> bool {
         self.permissions.contains(&Permission {
             permission: permission.to_string(),
@@ -25,22 +29,27 @@ impl Auth {
         })
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have all of the given `perms`
     pub fn has_all_permissions(&self, perms: Vec<String>) -> bool {
         perms.iter().all(|p| self.has_permission(p.to_string()))
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have any of the given `perms`
     pub fn has_any_permissions(&self, perms: Vec<String>) -> bool {
         perms.iter().any(|p| self.has_permission(p.to_string()))
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have the given `role`
     pub fn has_role(&self, permission: String) -> bool {
         self.roles.contains(&permission.to_string())
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have all of the given `roles`
     pub fn has_all_roles(&self, roles: Vec<String>) -> bool {
         roles.iter().all(|r| self.has_role(r.to_string()))
     }
 
+    /// does the user with the id [`self.user_id`](`ID`) have any of the given `roles`
     pub fn has_any_roles(&self, roles: Vec<String>) -> bool {
         roles.iter().any(|r| self.has_role(r.to_string()))
     }
@@ -48,6 +57,7 @@ impl Auth {
 
 #[async_trait]
 impl<'a> FromRequest<'a> for Auth {
+    /// extracts [`Auth`] from the given [`req`](`Request`)
     async fn from_request(req: &'a Request, _: &mut RequestBody) -> Result<Self> {
         let auth_header_opt: Option<&HeaderValue> = req.headers().get("Authorization");
 

--- a/create-rust-app/src/auth/mod.rs
+++ b/create-rust-app/src/auth/mod.rs
@@ -33,6 +33,13 @@ type UTC = chrono::NaiveDateTime;
 
 #[tsync::tsync]
 #[derive(Deserialize)]
+/// Rust struct that provides the information needed to allow 
+/// pagination of results for requests that have a lot of results
+/// 
+/// often times, GET requests to a REST API will have a lot of 
+/// results to return, pagination allows the server to break up
+/// those results into smaller chunks that can be more easily 
+/// sent to, and used by, the client
 pub struct PaginationParams {
     pub page: i64,
     pub page_size: i64,
@@ -44,6 +51,8 @@ impl PaginationParams {
 
 #[tsync::tsync]
 #[derive(Debug, Serialize, Deserialize, Clone)]
+/// Rust struct representation of a entry from the databases user_session table 
+/// serialized into Json
 pub struct UserSessionJson {
     pub id: ID,
     pub device: Option<String>,
@@ -54,6 +63,8 @@ pub struct UserSessionJson {
 
 #[tsync::tsync]
 #[derive(Debug, Serialize, Deserialize, Clone)]
+/// Rust struct representation of the 
+/// backends JSON response to a GET request at the /sessions endpoint
 pub struct UserSessionResponse {
     pub sessions: Vec<UserSessionJson>,
     pub num_pages: i64,
@@ -61,6 +72,7 @@ pub struct UserSessionResponse {
 
 #[tsync::tsync]
 #[derive(Debug, Serialize, Deserialize)]
+/// TODO: documentation
 pub struct AccessTokenClaims {
     pub exp: usize,
     pub sub: ID,

--- a/create-rust-app/src/auth/mod.rs
+++ b/create-rust-app/src/auth/mod.rs
@@ -33,12 +33,12 @@ type UTC = chrono::NaiveDateTime;
 
 #[tsync::tsync]
 #[derive(Deserialize)]
-/// Rust struct that provides the information needed to allow 
+/// Rust struct that provides the information needed to allow
 /// pagination of results for requests that have a lot of results
-/// 
-/// often times, GET requests to a REST API will have a lot of 
+///
+/// often times, GET requests to a REST API will have a lot of
 /// results to return, pagination allows the server to break up
-/// those results into smaller chunks that can be more easily 
+/// those results into smaller chunks that can be more easily
 /// sent to, and used by, the client
 pub struct PaginationParams {
     pub page: i64,
@@ -51,7 +51,7 @@ impl PaginationParams {
 
 #[tsync::tsync]
 #[derive(Debug, Serialize, Deserialize, Clone)]
-/// Rust struct representation of a entry from the databases user_session table 
+/// Rust struct representation of a entry from the databases user_session table
 /// serialized into Json
 pub struct UserSessionJson {
     pub id: ID,
@@ -63,7 +63,7 @@ pub struct UserSessionJson {
 
 #[tsync::tsync]
 #[derive(Debug, Serialize, Deserialize, Clone)]
-/// Rust struct representation of the 
+/// Rust struct representation of the
 /// backends JSON response to a GET request at the /sessions endpoint
 pub struct UserSessionResponse {
     pub sessions: Vec<UserSessionJson>,

--- a/create-rust-app/src/auth/permissions/mod.rs
+++ b/create-rust-app/src/auth/permissions/mod.rs
@@ -28,7 +28,7 @@ struct RoleQueryRow {
 
 impl Role {
     /// assign `role` to the User whose id is [`user_id`](`ID`)
-    /// 
+    ///
     /// Returns true if successful
     pub fn assign(db: &mut Connection, user_id: ID, role: &str) -> Result<bool> {
         let assigned = UserRole::create(
@@ -43,7 +43,7 @@ impl Role {
     }
 
     /// assigns every role in `roles` to the User whose id is [`user_id`](`ID`)
-    /// 
+    ///
     /// returns true if successful
     pub fn assign_many(db: &mut Connection, user_id: ID, roles: Vec<String>) -> Result<bool> {
         let assigned = UserRole::create_many(
@@ -61,7 +61,7 @@ impl Role {
     }
 
     /// unassigns `role` from the User whose id is [`user_id`](`ID`)
-    /// 
+    ///
     /// returns true if successful
     pub fn unassign(db: &mut Connection, user_id: ID, role: &str) -> Result<bool> {
         let unassigned = UserRole::delete(db, user_id, role.to_string());
@@ -70,7 +70,7 @@ impl Role {
     }
 
     /// unassigns every role in `roles` from the User whose id is [`user_id`](`ID`)
-    /// 
+    ///
     /// returns true if successful
     pub fn unassign_many(db: &mut Connection, user_id: ID, roles: Vec<String>) -> Result<bool> {
         let unassigned = UserRole::delete_many(db, user_id, roles);
@@ -126,7 +126,7 @@ impl Permission {
     // }
 
     /// grants `permission` to the User whose id is [`user_id`](`ID`)
-    /// 
+    ///
     /// returns true if successful
     pub fn grant_to_user(db: &mut Connection, user_id: ID, permission: &str) -> Result<bool> {
         let granted = UserPermission::create(
@@ -141,7 +141,7 @@ impl Permission {
     }
 
     /// grant `permission` to `role`
-    /// 
+    ///
     /// returns true if successful
     pub fn grant_to_role(db: &mut Connection, role: &str, permission: &str) -> Result<bool> {
         let granted = RolePermission::create(
@@ -156,7 +156,7 @@ impl Permission {
     }
 
     /// grants every permission in `permissions` to `role`
-    /// 
+    ///
     /// returns true if successful
     pub fn grant_many_to_role(
         db: &mut Connection,
@@ -178,7 +178,7 @@ impl Permission {
     }
 
     /// grants every permission in `permissions` to `role`
-    /// 
+    ///
     /// returns true if successful
     pub fn grant_many_to_user(
         db: &mut Connection,
@@ -200,7 +200,7 @@ impl Permission {
     }
 
     /// revokes `permission` from the User whose id is [`user_id`](`ID`)
-    /// 
+    ///
     /// returns true if successful
     pub fn revoke_from_user(db: &mut Connection, user_id: ID, permission: &str) -> Result<bool> {
         let deleted = UserPermission::delete(db, user_id, permission.to_string());
@@ -209,7 +209,7 @@ impl Permission {
     }
 
     /// revokes `permission` from `role`
-    /// 
+    ///
     /// returns true if successful
     pub fn revoke_from_role(db: &mut Connection, role: String, permission: String) -> Result<bool> {
         let deleted = RolePermission::delete(db, role, permission.to_string());
@@ -218,7 +218,7 @@ impl Permission {
     }
 
     /// revokes every permission in `permissions` from the User whose id is [`user_id`](`ID`)
-    /// 
+    ///
     /// returns true if successful
     pub fn revoke_many_from_user(
         db: &mut Connection,
@@ -231,7 +231,7 @@ impl Permission {
     }
 
     /// revokes every permission in `permissions` from `role`
-    /// 
+    ///
     /// returns true if successful
     pub fn revoke_many_from_role(
         db: &mut Connection,
@@ -244,7 +244,7 @@ impl Permission {
     }
 
     /// revokes every permission granted to `role`
-    /// 
+    ///
     /// returns true if successful
     pub fn revoke_all_from_role(db: &mut Connection, role: &str) -> Result<bool> {
         let deleted = RolePermission::delete_all(db, role);
@@ -253,7 +253,7 @@ impl Permission {
     }
 
     /// revokes every permission granted to the User whose id is [`user_id`](`ID`)
-    /// 
+    ///
     /// returns true if successful
     pub fn revoke_all_from_user(db: &mut Connection, user_id: i32) -> Result<bool> {
         let deleted = UserPermission::delete_all(db, user_id);

--- a/create-rust-app/src/auth/permissions/mod.rs
+++ b/create-rust-app/src/auth/permissions/mod.rs
@@ -27,6 +27,9 @@ struct RoleQueryRow {
 }
 
 impl Role {
+    /// assign `role` to the User whose id is [`user_id`](`ID`)
+    /// 
+    /// Returns true if successful
     pub fn assign(db: &mut Connection, user_id: ID, role: &str) -> Result<bool> {
         let assigned = UserRole::create(
             db,
@@ -39,6 +42,9 @@ impl Role {
         Ok(assigned.is_ok())
     }
 
+    /// assigns every role in `roles` to the User whose id is [`user_id`](`ID`)
+    /// 
+    /// returns true if successful
     pub fn assign_many(db: &mut Connection, user_id: ID, roles: Vec<String>) -> Result<bool> {
         let assigned = UserRole::create_many(
             db,
@@ -54,18 +60,25 @@ impl Role {
         Ok(assigned.is_ok())
     }
 
+    /// unassigns `role` from the User whose id is [`user_id`](`ID`)
+    /// 
+    /// returns true if successful
     pub fn unassign(db: &mut Connection, user_id: ID, role: &str) -> Result<bool> {
         let unassigned = UserRole::delete(db, user_id, role.to_string());
 
         Ok(unassigned.is_ok())
     }
 
+    /// unassigns every role in `roles` from the User whose id is [`user_id`](`ID`)
+    /// 
+    /// returns true if successful
     pub fn unassign_many(db: &mut Connection, user_id: ID, roles: Vec<String>) -> Result<bool> {
         let unassigned = UserRole::delete_many(db, user_id, roles);
 
         Ok(unassigned.is_ok())
     }
 
+    /// returns a vector containing every role assigned to the User whose id is [`user_id`](`ID`)
     pub fn fetch_all(db: &mut Connection, user_id: ID) -> Result<Vec<String>> {
         let roles = sql_query("SELECT role FROM user_roles WHERE user_id = $1");
 
@@ -83,9 +96,11 @@ impl Role {
 #[derive(Debug, Serialize, Deserialize, QueryableByName, Clone)]
 pub struct Permission {
     #[diesel(sql_type=Text)]
+    /// the role this permission is coming from
     pub from_role: String,
 
     #[diesel(sql_type=Text)]
+    /// the permission itself
     pub permission: String,
 }
 
@@ -110,6 +125,9 @@ impl Permission {
     //   Ok(user_has_permission)
     // }
 
+    /// grants `permission` to the User whose id is [`user_id`](`ID`)
+    /// 
+    /// returns true if successful
     pub fn grant_to_user(db: &mut Connection, user_id: ID, permission: &str) -> Result<bool> {
         let granted = UserPermission::create(
             db,
@@ -122,6 +140,9 @@ impl Permission {
         Ok(granted.is_ok())
     }
 
+    /// grant `permission` to `role`
+    /// 
+    /// returns true if successful
     pub fn grant_to_role(db: &mut Connection, role: &str, permission: &str) -> Result<bool> {
         let granted = RolePermission::create(
             db,
@@ -134,6 +155,9 @@ impl Permission {
         Ok(granted.is_ok())
     }
 
+    /// grants every permission in `permissions` to `role`
+    /// 
+    /// returns true if successful
     pub fn grant_many_to_role(
         db: &mut Connection,
         role: String,
@@ -153,6 +177,9 @@ impl Permission {
         Ok(granted.is_ok())
     }
 
+    /// grants every permission in `permissions` to `role`
+    /// 
+    /// returns true if successful
     pub fn grant_many_to_user(
         db: &mut Connection,
         user_id: i32,
@@ -172,18 +199,27 @@ impl Permission {
         Ok(granted.is_ok())
     }
 
+    /// revokes `permission` from the User whose id is [`user_id`](`ID`)
+    /// 
+    /// returns true if successful
     pub fn revoke_from_user(db: &mut Connection, user_id: ID, permission: &str) -> Result<bool> {
         let deleted = UserPermission::delete(db, user_id, permission.to_string());
 
         Ok(deleted.is_ok())
     }
 
+    /// revokes `permission` from `role`
+    /// 
+    /// returns true if successful
     pub fn revoke_from_role(db: &mut Connection, role: String, permission: String) -> Result<bool> {
         let deleted = RolePermission::delete(db, role, permission.to_string());
 
         Ok(deleted.is_ok())
     }
 
+    /// revokes every permission in `permissions` from the User whose id is [`user_id`](`ID`)
+    /// 
+    /// returns true if successful
     pub fn revoke_many_from_user(
         db: &mut Connection,
         user_id: ID,
@@ -194,6 +230,9 @@ impl Permission {
         Ok(deleted.is_ok())
     }
 
+    /// revokes every permission in `permissions` from `role`
+    /// 
+    /// returns true if successful
     pub fn revoke_many_from_role(
         db: &mut Connection,
         role: String,
@@ -204,18 +243,25 @@ impl Permission {
         Ok(deleted.is_ok())
     }
 
+    /// revokes every permission granted to `role`
+    /// 
+    /// returns true if successful
     pub fn revoke_all_from_role(db: &mut Connection, role: &str) -> Result<bool> {
         let deleted = RolePermission::delete_all(db, role);
 
         Ok(deleted.is_ok())
     }
 
+    /// revokes every permission granted to the User whose id is [`user_id`](`ID`)
+    /// 
+    /// returns true if successful
     pub fn revoke_all_from_user(db: &mut Connection, user_id: i32) -> Result<bool> {
         let deleted = UserPermission::delete_all(db, user_id);
 
         Ok(deleted.is_ok())
     }
 
+    /// returns every permission granted to the User whose id is [`user_id`](`ID`)
     pub fn fetch_all(db: &mut Connection, user_id: ID) -> Result<Vec<Permission>> {
         let permissions = sql_query(
             r#"

--- a/create-rust-app/src/auth/permissions/role_permission.rs
+++ b/create-rust-app/src/auth/permissions/role_permission.rs
@@ -32,7 +32,7 @@ pub struct RolePermissionChangeset {
 
 /// CRUD functions for [`RolePermission`]
 impl RolePermission {
-    /// Create an entry in the database's role_permissions table that has the data stored in [`item`](`RolePermissionChangeset`)
+    /// Create an entry in [`db`](`Connection`)'s role_permissions table that has the data stored in [`item`](`RolePermissionChangeset`)
     pub fn create(db: &mut Connection, item: &RolePermissionChangeset) -> QueryResult<Self> {
         use crate::auth::schema::role_permissions::dsl::*;
 
@@ -42,7 +42,7 @@ impl RolePermission {
     }
 
     #[cfg(feature = "database_sqlite")]
-    /// Create an entry in the database's role_permissions table for each [element](`RolePermissionChangeset`) in `items`
+    /// Create an entry in [`db`](`Connection`)'s role_permissions table for each [element](`RolePermissionChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,
         items: Vec<RolePermissionChangeset>,
@@ -55,7 +55,7 @@ impl RolePermission {
     }
 
     #[cfg(not(feature = "database_sqlite"))]
-    /// Create an entry in the database's role_permissions table for each [element](`RolePermissionChangeset`) in `items`
+    /// Create an entry in [`db`](`Connection`)'s role_permissions table for each [element](`RolePermissionChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,
         items: Vec<RolePermissionChangeset>,
@@ -92,7 +92,7 @@ impl RolePermission {
             .load::<RolePermission>(db)
     }
 
-    /// Delete the entry in the database's role_permissions table that has 
+    /// Delete the entry in [`db`](`Connection`)'s role_permissions table that has 
     /// (`item_role`,`item_permission`) as it's primary keys
     pub fn delete(
         db: &mut Connection,
@@ -107,7 +107,7 @@ impl RolePermission {
             .execute(db)
     }
 
-    /// Delete every entry in the database's role_permissions table that has 
+    /// Delete every entry in [`db`](`Connection`)'s role_permissions table that has 
     /// `item_role`, and an element of`item_permissions` as it's primary keys
     pub fn delete_many(
         db: &mut Connection,
@@ -124,7 +124,7 @@ impl RolePermission {
             .execute(db)
     }
 
-    /// Delete the entry in the database's role_permissions table that has 
+    /// Delete the entry in [`db`](`Connection`)'s role_permissions table that has 
     /// `item_role` as one of it's primary keys
     pub fn delete_all(db: &mut Connection, item_role: &str) -> QueryResult<usize> {
         use crate::auth::schema::role_permissions::dsl::*;

--- a/create-rust-app/src/auth/permissions/role_permission.rs
+++ b/create-rust-app/src/auth/permissions/role_permission.rs
@@ -7,6 +7,7 @@ use crate::diesel::*;
 #[tsync::tsync]
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
 #[diesel(table_name = role_permissions)]
+/// Rust struct modeling an entry in the role_permissions table
 pub struct RolePermission {
     /* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     Add columns here in the same order as the schema
@@ -18,6 +19,7 @@ pub struct RolePermission {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Insertable, AsChangeset)]
 #[diesel(table_name = role_permissions)]
+/// Rust struct modeling mutable data in an entry in the role_permissions table
 pub struct RolePermissionChangeset {
     /* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     Add columns here in the same order as the schema
@@ -28,7 +30,9 @@ pub struct RolePermissionChangeset {
     pub permission: String,
 }
 
+/// CRUD functions for [`RolePermission`]
 impl RolePermission {
+    /// Create an entry in the database's role_permissions table that has the data stored in [`item`](`RolePermissionChangeset`)
     pub fn create(db: &mut Connection, item: &RolePermissionChangeset) -> QueryResult<Self> {
         use crate::auth::schema::role_permissions::dsl::*;
 
@@ -38,6 +42,7 @@ impl RolePermission {
     }
 
     #[cfg(feature = "database_sqlite")]
+    /// Create an entry in the database's role_permissions table for each [element](`RolePermissionChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,
         items: Vec<RolePermissionChangeset>,
@@ -50,6 +55,7 @@ impl RolePermission {
     }
 
     #[cfg(not(feature = "database_sqlite"))]
+    /// Create an entry in the database's role_permissions table for each [element](`RolePermissionChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,
         items: Vec<RolePermissionChangeset>,
@@ -61,6 +67,8 @@ impl RolePermission {
             .get_results::<RolePermission>(db)
     }
 
+    /// Read from [`db`](`Connection`), querying for an entry in the role_permissions table that has 
+    /// (`item_role`,`item_permission`) as it's primary keys
     pub fn read(
         db: &mut Connection,
         item_role: String,
@@ -73,6 +81,8 @@ impl RolePermission {
             .first::<RolePermission>(db)
     }
 
+    /// Read from [`db`](`Connection`), querying for every entry in the role_permissions table that has
+    /// `item_role` as one of its primary keys
     pub fn read_all(db: &mut Connection, item_role: String) -> QueryResult<Vec<Self>> {
         use crate::auth::schema::role_permissions::dsl::*;
 
@@ -82,6 +92,8 @@ impl RolePermission {
             .load::<RolePermission>(db)
     }
 
+    /// Delete the entry in the database's role_permissions table that has 
+    /// (`item_role`,`item_permission`) as it's primary keys
     pub fn delete(
         db: &mut Connection,
         item_role: String,
@@ -95,6 +107,8 @@ impl RolePermission {
             .execute(db)
     }
 
+    /// Delete every entry in the database's role_permissions table that has 
+    /// `item_role`, and an element of`item_permissions` as it's primary keys
     pub fn delete_many(
         db: &mut Connection,
         item_role: String,
@@ -110,6 +124,8 @@ impl RolePermission {
             .execute(db)
     }
 
+    /// Delete the entry in the database's role_permissions table that has 
+    /// `item_role` as one of it's primary keys
     pub fn delete_all(db: &mut Connection, item_role: &str) -> QueryResult<usize> {
         use crate::auth::schema::role_permissions::dsl::*;
 

--- a/create-rust-app/src/auth/permissions/role_permission.rs
+++ b/create-rust-app/src/auth/permissions/role_permission.rs
@@ -67,7 +67,7 @@ impl RolePermission {
             .get_results::<RolePermission>(db)
     }
 
-    /// Read from [`db`](`Connection`), querying for an entry in the role_permissions table that has 
+    /// Read from [`db`](`Connection`), querying for an entry in the role_permissions table that has
     /// (`item_role`,`item_permission`) as it's primary keys
     pub fn read(
         db: &mut Connection,
@@ -92,7 +92,7 @@ impl RolePermission {
             .load::<RolePermission>(db)
     }
 
-    /// Delete the entry in [`db`](`Connection`)'s role_permissions table that has 
+    /// Delete the entry in [`db`](`Connection`)'s role_permissions table that has
     /// (`item_role`,`item_permission`) as it's primary keys
     pub fn delete(
         db: &mut Connection,
@@ -107,7 +107,7 @@ impl RolePermission {
             .execute(db)
     }
 
-    /// Delete every entry in [`db`](`Connection`)'s role_permissions table that has 
+    /// Delete every entry in [`db`](`Connection`)'s role_permissions table that has
     /// `item_role`, and an element of`item_permissions` as it's primary keys
     pub fn delete_many(
         db: &mut Connection,
@@ -124,7 +124,7 @@ impl RolePermission {
             .execute(db)
     }
 
-    /// Delete the entry in [`db`](`Connection`)'s role_permissions table that has 
+    /// Delete the entry in [`db`](`Connection`)'s role_permissions table that has
     /// `item_role` as one of it's primary keys
     pub fn delete_all(db: &mut Connection, item_role: &str) -> QueryResult<usize> {
         use crate::auth::schema::role_permissions::dsl::*;

--- a/create-rust-app/src/auth/permissions/user_permission.rs
+++ b/create-rust-app/src/auth/permissions/user_permission.rs
@@ -13,6 +13,7 @@ use crate::{
     Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Associations, AsChangeset,
 )]
 #[diesel(table_name=user_permissions,belongs_to(User))]
+/// Rust struct modeling an entry in the user_permissions table
 pub struct UserPermission {
     /* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     Add columns here in the same order as the schema
@@ -24,6 +25,7 @@ pub struct UserPermission {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Insertable, AsChangeset)]
 #[diesel(table_name=user_permissions)]
+/// Rust struct modeling mutable data in an entry in the user_permissions table
 pub struct UserPermissionChangeset {
     /* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     Add columns here in the same order as the schema
@@ -34,7 +36,9 @@ pub struct UserPermissionChangeset {
     pub permission: String,
 }
 
+/// CRUD functions for [`UserPermission`]
 impl UserPermission {
+    /// Create an entry in the database's user_permissions table that has the data stored in [`item`](`UserPermissionChangeset`)
     pub fn create(db: &mut Connection, item: &UserPermissionChangeset) -> QueryResult<Self> {
         use crate::auth::schema::user_permissions::dsl::*;
 
@@ -44,6 +48,7 @@ impl UserPermission {
     }
 
     #[cfg(feature="database_sqlite")]
+    /// Create an entry in the database's user_permissions table for each [element](`UserPermissionChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,
         items: Vec<UserPermissionChangeset>,
@@ -56,6 +61,7 @@ impl UserPermission {
     }
 
     #[cfg(not(feature="database_sqlite"))]
+    /// Create an entry in the database's user_permissions table for each [element](`UserPermissionChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,
         items: Vec<UserPermissionChangeset>,
@@ -67,6 +73,8 @@ impl UserPermission {
             .get_result::<UserPermission>(db)
     }
 
+    /// Read from [`db`](`Connection`), querying for an entry in the user_permissions table that has 
+    /// (`item_user_id`,`item_permission`) as it's primary keys
     pub fn read(
         db: &mut Connection,
         item_user_id: ID,
@@ -79,6 +87,8 @@ impl UserPermission {
             .first::<UserPermission>(db)
     }
 
+    /// Read from [`db`](`Connection`), querying for every entry in the user_permissions table that has
+    /// `item_user_id` as one of its primary keys
     pub fn read_all(db: &mut Connection, item_user_id: ID) -> QueryResult<Vec<Self>> {
         use crate::auth::schema::user_permissions::dsl::*;
 
@@ -88,6 +98,8 @@ impl UserPermission {
             .load::<UserPermission>(db)
     }
 
+    /// Delete the entry in the database's user_permissions table that has 
+    /// (`item_user_id`,`item_permission`) as it's primary keys
     pub fn delete(
         db: &mut Connection,
         item_user_id: ID,
@@ -101,6 +113,8 @@ impl UserPermission {
         .execute(db)
     }
 
+    /// Delete every entry in the database's user_permissions table that has 
+    /// `item_user_id`, and an element of`item_permissions` as it's primary keys
     pub fn delete_many(
         db: &mut Connection,
         item_user_id: ID,
@@ -116,6 +130,8 @@ impl UserPermission {
         .execute(db)
     }
 
+    /// Delete the entry in the database's user_permissions table that has 
+    /// `item_user_id` as one of it's primary keys
     pub fn delete_all(db: &mut Connection, item_user_id: ID) -> QueryResult<usize> {
         use crate::auth::schema::user_permissions::dsl::*;
 

--- a/create-rust-app/src/auth/permissions/user_permission.rs
+++ b/create-rust-app/src/auth/permissions/user_permission.rs
@@ -38,7 +38,7 @@ pub struct UserPermissionChangeset {
 
 /// CRUD functions for [`UserPermission`]
 impl UserPermission {
-    /// Create an entry in the database's user_permissions table that has the data stored in [`item`](`UserPermissionChangeset`)
+    /// Create an entry in [`db`](`Connection`)'s user_permissions table that has the data stored in [`item`](`UserPermissionChangeset`)
     pub fn create(db: &mut Connection, item: &UserPermissionChangeset) -> QueryResult<Self> {
         use crate::auth::schema::user_permissions::dsl::*;
 
@@ -48,7 +48,7 @@ impl UserPermission {
     }
 
     #[cfg(feature="database_sqlite")]
-    /// Create an entry in the database's user_permissions table for each [element](`UserPermissionChangeset`) in `items`
+    /// Create an entry in [`db`](`Connection`)'s user_permissions table for each [element](`UserPermissionChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,
         items: Vec<UserPermissionChangeset>,
@@ -61,7 +61,7 @@ impl UserPermission {
     }
 
     #[cfg(not(feature="database_sqlite"))]
-    /// Create an entry in the database's user_permissions table for each [element](`UserPermissionChangeset`) in `items`
+    /// Create an entry in [`db`](`Connection`)'s user_permissions table for each [element](`UserPermissionChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,
         items: Vec<UserPermissionChangeset>,
@@ -98,7 +98,7 @@ impl UserPermission {
             .load::<UserPermission>(db)
     }
 
-    /// Delete the entry in the database's user_permissions table that has 
+    /// Delete the entry in [`db`](`Connection`)'s user_permissions table that has 
     /// (`item_user_id`,`item_permission`) as it's primary keys
     pub fn delete(
         db: &mut Connection,
@@ -113,7 +113,7 @@ impl UserPermission {
         .execute(db)
     }
 
-    /// Delete every entry in the database's user_permissions table that has 
+    /// Delete every entry in [`db`](`Connection`)'s user_permissions table that has 
     /// `item_user_id`, and an element of`item_permissions` as it's primary keys
     pub fn delete_many(
         db: &mut Connection,
@@ -130,7 +130,7 @@ impl UserPermission {
         .execute(db)
     }
 
-    /// Delete the entry in the database's user_permissions table that has 
+    /// Delete the entry in [`db`](`Connection`)'s user_permissions table that has 
     /// `item_user_id` as one of it's primary keys
     pub fn delete_all(db: &mut Connection, item_user_id: ID) -> QueryResult<usize> {
         use crate::auth::schema::user_permissions::dsl::*;

--- a/create-rust-app/src/auth/permissions/user_permission.rs
+++ b/create-rust-app/src/auth/permissions/user_permission.rs
@@ -73,7 +73,7 @@ impl UserPermission {
             .get_result::<UserPermission>(db)
     }
 
-    /// Read from [`db`](`Connection`), querying for an entry in the user_permissions table that has 
+    /// Read from [`db`](`Connection`), querying for an entry in the user_permissions table that has
     /// (`item_user_id`,`item_permission`) as it's primary keys
     pub fn read(
         db: &mut Connection,
@@ -98,7 +98,7 @@ impl UserPermission {
             .load::<UserPermission>(db)
     }
 
-    /// Delete the entry in [`db`](`Connection`)'s user_permissions table that has 
+    /// Delete the entry in [`db`](`Connection`)'s user_permissions table that has
     /// (`item_user_id`,`item_permission`) as it's primary keys
     pub fn delete(
         db: &mut Connection,
@@ -113,7 +113,7 @@ impl UserPermission {
         .execute(db)
     }
 
-    /// Delete every entry in [`db`](`Connection`)'s user_permissions table that has 
+    /// Delete every entry in [`db`](`Connection`)'s user_permissions table that has
     /// `item_user_id`, and an element of`item_permissions` as it's primary keys
     pub fn delete_many(
         db: &mut Connection,
@@ -130,7 +130,7 @@ impl UserPermission {
         .execute(db)
     }
 
-    /// Delete the entry in [`db`](`Connection`)'s user_permissions table that has 
+    /// Delete the entry in [`db`](`Connection`)'s user_permissions table that has
     /// `item_user_id` as one of it's primary keys
     pub fn delete_all(db: &mut Connection, item_user_id: ID) -> QueryResult<usize> {
         use crate::auth::schema::user_permissions::dsl::*;

--- a/create-rust-app/src/auth/permissions/user_role.rs
+++ b/create-rust-app/src/auth/permissions/user_role.rs
@@ -67,7 +67,7 @@ impl UserRole {
             .get_results::<UserRole>(db)
     }
 
-    /// Read from [`db`](`Connection`), querying for an entry in the user_roles table that has 
+    /// Read from [`db`](`Connection`), querying for an entry in the user_roles table that has
     /// (`item_user_id`,`item_role`) as it's primary keys
     pub fn read(db: &mut Connection, item_user_id: ID, item_role: String) -> QueryResult<Self> {
         use crate::auth::schema::user_roles::dsl::*;
@@ -88,7 +88,7 @@ impl UserRole {
             .load::<UserRole>(db)
     }
 
-    /// Delete the entry in [`db`](`Connection`)'s user_roles table that has 
+    /// Delete the entry in [`db`](`Connection`)'s user_roles table that has
     /// (`item_user_id`,`item_role`) as it's primary keys
     pub fn delete(db: &mut Connection, item_user_id: ID, item_role: String) -> QueryResult<usize> {
         use crate::auth::schema::user_roles::dsl::*;
@@ -97,7 +97,7 @@ impl UserRole {
             .execute(db)
     }
 
-    /// Delete every entry in [`db`](`Connection`)'s user_roles table that has 
+    /// Delete every entry in [`db`](`Connection`)'s user_roles table that has
     /// `item_user_id`, and an element of`item_roles` as it's primary keys
     pub fn delete_many(
         db: &mut Connection,

--- a/create-rust-app/src/auth/permissions/user_role.rs
+++ b/create-rust-app/src/auth/permissions/user_role.rs
@@ -37,7 +37,7 @@ pub struct UserRoleChangeset {
 }
 
 impl UserRole {
-    /// Create an entry in the database's user_roles table that has the data stored in [`item`](`UserRoleChangeset`)
+    /// Create an entry in [`db`](`Connection`)'s user_roles table that has the data stored in [`item`](`UserRoleChangeset`)
     pub fn create(db: &mut Connection, item: &UserRoleChangeset) -> QueryResult<Self> {
         use crate::auth::schema::user_roles::dsl::*;
 
@@ -47,7 +47,7 @@ impl UserRole {
     }
 
     #[cfg(feature = "database_sqlite")]
-    /// Create an entry in the database's user_roles table for each [element](`UserRoleChangeset`) in `items`
+    /// Create an entry in [`db`](`Connection`)'s user_roles table for each [element](`UserRoleChangeset`) in `items`
     pub fn create_many(db: &mut Connection, items: Vec<UserRoleChangeset>) -> QueryResult<usize> {
         use crate::auth::schema::user_roles::dsl::*;
 
@@ -55,7 +55,7 @@ impl UserRole {
     }
 
     #[cfg(not(feature = "database_sqlite"))]
-    /// Create an entry in the database's user_roles table for each [element](`UserRoleChangeset`) in `items`
+    /// Create an entry in [`db`](`Connection`)'s user_roles table for each [element](`UserRoleChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,
         items: Vec<UserRoleChangeset>,
@@ -88,7 +88,7 @@ impl UserRole {
             .load::<UserRole>(db)
     }
 
-    /// Delete the entry in the database's user_roles table that has 
+    /// Delete the entry in [`db`](`Connection`)'s user_roles table that has 
     /// (`item_user_id`,`item_role`) as it's primary keys
     pub fn delete(db: &mut Connection, item_user_id: ID, item_role: String) -> QueryResult<usize> {
         use crate::auth::schema::user_roles::dsl::*;
@@ -97,7 +97,7 @@ impl UserRole {
             .execute(db)
     }
 
-    /// Delete every entry in the database's user_roles table that has 
+    /// Delete every entry in [`db`](`Connection`)'s user_roles table that has 
     /// `item_user_id`, and an element of`item_roles` as it's primary keys
     pub fn delete_many(
         db: &mut Connection,

--- a/create-rust-app/src/auth/permissions/user_role.rs
+++ b/create-rust-app/src/auth/permissions/user_role.rs
@@ -13,6 +13,7 @@ use crate::{
     Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Associations, AsChangeset,
 )]
 #[diesel(table_name = user_roles, belongs_to(User))]
+/// Rust struct modeling an entry in the user_roles table
 pub struct UserRole {
     /* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     Add columns here in the same order as the schema
@@ -24,6 +25,7 @@ pub struct UserRole {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Insertable, AsChangeset)]
 #[diesel(table_name = user_roles)]
+/// Rust struct modeling mutable data in an entry in the user_roles table
 pub struct UserRoleChangeset {
     /* -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
     Add columns here in the same order as the schema
@@ -35,6 +37,7 @@ pub struct UserRoleChangeset {
 }
 
 impl UserRole {
+    /// Create an entry in the database's user_roles table that has the data stored in [`item`](`UserRoleChangeset`)
     pub fn create(db: &mut Connection, item: &UserRoleChangeset) -> QueryResult<Self> {
         use crate::auth::schema::user_roles::dsl::*;
 
@@ -44,6 +47,7 @@ impl UserRole {
     }
 
     #[cfg(feature = "database_sqlite")]
+    /// Create an entry in the database's user_roles table for each [element](`UserRoleChangeset`) in `items`
     pub fn create_many(db: &mut Connection, items: Vec<UserRoleChangeset>) -> QueryResult<usize> {
         use crate::auth::schema::user_roles::dsl::*;
 
@@ -51,6 +55,7 @@ impl UserRole {
     }
 
     #[cfg(not(feature = "database_sqlite"))]
+    /// Create an entry in the database's user_roles table for each [element](`UserRoleChangeset`) in `items`
     pub fn create_many(
         db: &mut Connection,
         items: Vec<UserRoleChangeset>,
@@ -62,6 +67,8 @@ impl UserRole {
             .get_results::<UserRole>(db)
     }
 
+    /// Read from [`db`](`Connection`), querying for an entry in the user_roles table that has 
+    /// (`item_user_id`,`item_role`) as it's primary keys
     pub fn read(db: &mut Connection, item_user_id: ID, item_role: String) -> QueryResult<Self> {
         use crate::auth::schema::user_roles::dsl::*;
 
@@ -70,6 +77,8 @@ impl UserRole {
             .first::<UserRole>(db)
     }
 
+    /// Read from [`db`](`Connection`), querying for every entry in the user_roles table that has
+    /// `item_user_id` as one of its primary keys
     pub fn read_all(db: &mut Connection, item_user_id: ID) -> QueryResult<Vec<Self>> {
         use crate::auth::schema::user_roles::dsl::*;
 
@@ -79,6 +88,8 @@ impl UserRole {
             .load::<UserRole>(db)
     }
 
+    /// Delete the entry in the database's user_roles table that has 
+    /// (`item_user_id`,`item_role`) as it's primary keys
     pub fn delete(db: &mut Connection, item_user_id: ID, item_role: String) -> QueryResult<usize> {
         use crate::auth::schema::user_roles::dsl::*;
 
@@ -86,6 +97,8 @@ impl UserRole {
             .execute(db)
     }
 
+    /// Delete every entry in the database's user_roles table that has 
+    /// `item_user_id`, and an element of`item_roles` as it's primary keys
     pub fn delete_many(
         db: &mut Connection,
         item_user_id: ID,

--- a/create-rust-app/src/auth/user.rs
+++ b/create-rust-app/src/auth/user.rs
@@ -1,21 +1,21 @@
 
-    /// Create an entry in [`db`](`Connection`)'s `users` table using the data in [`item`](`UserChangeset`)
-    
-/// Read from [`db`](`Connection`), querying for an entry in the `users` 
-    /// who's primary key matches [`item_id`](`ID`)
-    
-/// Queries [`db`](`Connection`)'s `users` table for an entry 
-    /// with an email that matches the given `item_email`
-    
+/// Create an entry in [`db`](`Connection`)'s `users` table using the data in [`item`](`UserChangeset`)
+
+/// Read from [`db`](`Connection`), querying for an entry in the `users`
+/// who's primary key matches [`item_id`](`ID`)
+
+/// Queries [`db`](`Connection`)'s `users` table for an entry
+/// with an email that matches the given `item_email`
+
 /// Read from [`db`](`Connection`), return entries of the `users` table,
-    /// paginated according to [`pagination`](`PaginationParams`)
-    
+/// paginated according to [`pagination`](`PaginationParams`)
+
 /// Update the entry in [`db`](`Connection`)'s `users` table who's primary key matches
-    /// [`item_id`](`ID`), with the data in [`item`](`UserChangeset`)
-    
-/// Delete the entry in [`db`](`Connection`)'s `users` table who's 
-    /// primary key matches [`item_id`](`ID`)
-    use super::schema::*;
+/// [`item_id`](`ID`), with the data in [`item`](`UserChangeset`)
+
+/// Delete the entry in [`db`](`Connection`)'s `users` table who's
+/// primary key matches [`item_id`](`ID`)
+use super::schema::*;
 use crate::diesel::*;
 
 use super::{PaginationParams, ID, UTC};
@@ -65,7 +65,7 @@ impl User {
         insert_into(users).values(item).get_result::<User>(db)
     }
 
-    /// Read from [`db`](`Connection`), querying for an entry in the `users` 
+    /// Read from [`db`](`Connection`), querying for an entry in the `users`
     /// who's primary key matches [`item_id`](`ID`)
     pub fn read(db: &mut Connection, item_id: ID) -> QueryResult<Self> {
         use super::schema::users::dsl::*;
@@ -73,7 +73,7 @@ impl User {
         users.filter(id.eq(item_id)).first::<User>(db)
     }
 
-    /// Queries [`db`](`Connection`)'s `users` table for an entry 
+    /// Queries [`db`](`Connection`)'s `users` table for an entry
     /// with an email that matches the given `item_email`
     pub fn find_by_email(db: &mut Connection, item_email: String) -> QueryResult<Self> {
         use super::schema::users::dsl::*;
@@ -106,7 +106,7 @@ impl User {
             .get_result(db)
     }
 
-    /// Delete the entry in [`db`](`Connection`)'s `users` table who's 
+    /// Delete the entry in [`db`](`Connection`)'s `users` table who's
     /// primary key matches [`item_id`](`ID`)
     pub fn delete(db: &mut Connection, item_id: ID) -> QueryResult<usize> {
         use super::schema::users::dsl::*;

--- a/create-rust-app/src/auth/user.rs
+++ b/create-rust-app/src/auth/user.rs
@@ -1,4 +1,21 @@
-use super::schema::*;
+
+    /// Create an entry in [`db`](`Connection`)'s `users` table using the data in [`item`](`UserChangeset`)
+    
+/// Read from [`db`](`Connection`), querying for an entry in the `users` 
+    /// who's primary key matches [`item_id`](`ID`)
+    
+/// Queries [`db`](`Connection`)'s `users` table for an entry 
+    /// with an email that matches the given `item_email`
+    
+/// Read from [`db`](`Connection`), return entries of the `users` table,
+    /// paginated according to [`pagination`](`PaginationParams`)
+    
+/// Update the entry in [`db`](`Connection`)'s `users` table who's primary key matches
+    /// [`item_id`](`ID`), with the data in [`item`](`UserChangeset`)
+    
+/// Delete the entry in [`db`](`Connection`)'s `users` table who's 
+    /// primary key matches [`item_id`](`ID`)
+    use super::schema::*;
 use crate::diesel::*;
 
 use super::{PaginationParams, ID, UTC};
@@ -41,24 +58,31 @@ pub struct UserChangeset {
 }
 
 impl User {
+    /// Create an entry in [`db`](`Connection`)'s `users` table using the data in [`item`](`UserChangeset`)
     pub fn create(db: &mut Connection, item: &UserChangeset) -> QueryResult<Self> {
         use super::schema::users::dsl::*;
 
         insert_into(users).values(item).get_result::<User>(db)
     }
 
+    /// Read from [`db`](`Connection`), querying for an entry in the `users` 
+    /// who's primary key matches [`item_id`](`ID`)
     pub fn read(db: &mut Connection, item_id: ID) -> QueryResult<Self> {
         use super::schema::users::dsl::*;
 
         users.filter(id.eq(item_id)).first::<User>(db)
     }
 
+    /// Queries [`db`](`Connection`)'s `users` table for an entry 
+    /// with an email that matches the given `item_email`
     pub fn find_by_email(db: &mut Connection, item_email: String) -> QueryResult<Self> {
         use super::schema::users::dsl::*;
 
         users.filter(email.eq(item_email)).first::<User>(db)
     }
 
+    /// Read from [`db`](`Connection`), return entries of the `users` table,
+    /// paginated according to [`pagination`](`PaginationParams`)
     pub fn read_all(db: &mut Connection, pagination: &PaginationParams) -> QueryResult<Vec<Self>> {
         use super::schema::users::dsl::*;
 
@@ -72,6 +96,8 @@ impl User {
             .load::<User>(db)
     }
 
+    /// Update the entry in [`db`](`Connection`)'s `users` table who's primary key matches
+    /// [`item_id`](`ID`), with the data in [`item`](`UserChangeset`)
     pub fn update(db: &mut Connection, item_id: ID, item: &UserChangeset) -> QueryResult<Self> {
         use super::schema::users::dsl::*;
 
@@ -80,6 +106,8 @@ impl User {
             .get_result(db)
     }
 
+    /// Delete the entry in [`db`](`Connection`)'s `users` table who's 
+    /// primary key matches [`item_id`](`ID`)
     pub fn delete(db: &mut Connection, item_id: ID) -> QueryResult<usize> {
         use super::schema::users::dsl::*;
 

--- a/create-rust-app/src/auth/user_session.rs
+++ b/create-rust-app/src/auth/user_session.rs
@@ -50,6 +50,7 @@ pub struct UserSessionChangeset {
 }
 
 impl UserSession {
+    /// Create an entry in [`db`](`Connection`)'s `user_sessions` table using the data in [`item`](`UserSessionChangeset`)
     pub fn create(db: &mut Connection, item: &UserSessionChangeset) -> QueryResult<Self> {
         use super::schema::user_sessions::dsl::*;
 
@@ -58,6 +59,8 @@ impl UserSession {
             .get_result::<UserSession>(db)
     }
 
+    /// Read from [`db`](`Connection`), querying for an entry in the `user_sessions` 
+    /// who's primary key matches [`item_id`](`ID`)
     pub fn read(db: &mut Connection, item_id: ID) -> QueryResult<Self> {
         use super::schema::user_sessions::dsl::*;
 
@@ -66,6 +69,8 @@ impl UserSession {
             .first::<UserSession>(db)
     }
 
+    /// Query [`db`](`Connection`)'s `user_sessions` table for an entry 
+    /// who's `refresh_token` matches the given `item_refresh_token`
     pub fn find_by_refresh_token(
         db: &mut Connection,
         item_refresh_token: &str,
@@ -77,6 +82,8 @@ impl UserSession {
             .first::<UserSession>(db)
     }
 
+    /// Read from [`db`](`Connection`), return entries of the `user_sessions` table,
+    /// paginated according to [`pagination`](`PaginationParams`)
     pub fn read_all(
         db: &mut Connection,
         pagination: &PaginationParams,
@@ -95,6 +102,8 @@ impl UserSession {
             .load::<UserSession>(db)
     }
 
+    /// Query [`db`](`Connection`) for all entries in the `user_sessions` table
+    /// who's `user_id` matches the given [`item_user_id`]
     pub fn count_all(db: &mut Connection, item_user_id: ID) -> QueryResult<i64> {
         use super::schema::user_sessions::dsl::*;
 
@@ -104,6 +113,8 @@ impl UserSession {
             .get_result(db)
     }
 
+    /// Update the entry in [`db`](`Connection`)'s `user_sessions` table who's primary key matches
+    /// [`item_id`](`ID`), with the data in [`item`](`UserSessionChangeset`)
     pub fn update(
         db: &mut Connection,
         item_id: ID,
@@ -116,12 +127,16 @@ impl UserSession {
             .get_result(db)
     }
 
+    /// Delete the entry in [`db`](`Connection`)'s `user_sessions` table who's 
+    /// primary key matches [`item_id`](`ID`)
     pub fn delete(db: &mut Connection, item_id: ID) -> QueryResult<usize> {
         use super::schema::user_sessions::dsl::*;
 
         diesel::delete(user_sessions.filter(id.eq(item_id))).execute(db)
     }
 
+    /// Delete all entries in [`db`](`Connection`)'s `user_sessions` table who's 
+    /// 'user_id' matches [`item_user_id`](`ID`)
     pub fn delete_all_for_user(db: &mut Connection, item_user_id: ID) -> QueryResult<usize> {
         use super::schema::user_sessions::dsl::*;
 

--- a/create-rust-app/src/auth/user_session.rs
+++ b/create-rust-app/src/auth/user_session.rs
@@ -59,7 +59,7 @@ impl UserSession {
             .get_result::<UserSession>(db)
     }
 
-    /// Read from [`db`](`Connection`), querying for an entry in the `user_sessions` 
+    /// Read from [`db`](`Connection`), querying for an entry in the `user_sessions`
     /// who's primary key matches [`item_id`](`ID`)
     pub fn read(db: &mut Connection, item_id: ID) -> QueryResult<Self> {
         use super::schema::user_sessions::dsl::*;
@@ -69,7 +69,7 @@ impl UserSession {
             .first::<UserSession>(db)
     }
 
-    /// Query [`db`](`Connection`)'s `user_sessions` table for an entry 
+    /// Query [`db`](`Connection`)'s `user_sessions` table for an entry
     /// who's `refresh_token` matches the given `item_refresh_token`
     pub fn find_by_refresh_token(
         db: &mut Connection,
@@ -127,7 +127,7 @@ impl UserSession {
             .get_result(db)
     }
 
-    /// Delete the entry in [`db`](`Connection`)'s `user_sessions` table who's 
+    /// Delete the entry in [`db`](`Connection`)'s `user_sessions` table who's
     /// primary key matches [`item_id`](`ID`)
     pub fn delete(db: &mut Connection, item_id: ID) -> QueryResult<usize> {
         use super::schema::user_sessions::dsl::*;
@@ -135,7 +135,7 @@ impl UserSession {
         diesel::delete(user_sessions.filter(id.eq(item_id))).execute(db)
     }
 
-    /// Delete all entries in [`db`](`Connection`)'s `user_sessions` table who's 
+    /// Delete all entries in [`db`](`Connection`)'s `user_sessions` table who's
     /// 'user_id' matches [`item_user_id`](`ID`)
     pub fn delete_all_for_user(db: &mut Connection, item_user_id: ID) -> QueryResult<usize> {
         use super::schema::user_sessions::dsl::*;

--- a/create-rust-app/src/database/mod.rs
+++ b/create-rust-app/src/database/mod.rs
@@ -10,11 +10,13 @@ pub type Pool = r2d2::Pool<ConnectionManager<DbCon>>;
 pub type Connection = PooledConnection<ConnectionManager<DbCon>>;
 
 #[derive(Clone)]
+/// wrapper function for a database pool
 pub struct Database {
     pub pool: Pool,
 }
 
 impl Database {
+    /// create a new [`Database`]
     pub fn new() -> Database {
         let database_url =
             std::env::var("DATABASE_URL").expect("DATABASE_URL environment variable expected.");
@@ -28,6 +30,7 @@ impl Database {
         }
     }
 
+    /// get a [`Connection`] to a database
     pub fn get_connection(&self) -> Connection {
         self.pool.get().unwrap()
     }

--- a/create-rust-app/src/lib.rs
+++ b/create-rust-app/src/lib.rs
@@ -39,19 +39,19 @@ pub use mailer::Mailer;
 // extern crate diesel_migrations;
 
 #[derive(Clone)]
-/// 
+///
 pub struct AppData {
     /// wrapper for SMTP mailing server accessed by chosen web framework
-    /// 
+    ///
     /// see [`Mailer`]
     pub mailer: Mailer,
     /// db agnostic wrapper for databases accessed by chosen web framework
-    /// 
+    ///
     /// see [`Database`]
     pub database: Database,
     #[cfg(feature = "plugin_storage")]
     /// wrapper for Amazon S3 cloud file storage service accessed by chosen web framework
-    /// 
+    ///
     /// see [`Storage`]
     pub storage: storage::Storage,
 }
@@ -59,7 +59,7 @@ pub struct AppData {
 /// ensures required environment variables are present,
 ///  
 /// initialize a [`Mailer`], [`Database`], and [`Storage`] (is `Storage` plugin was enabled ("plugin_storage" feature enabled))
-/// 
+///
 /// and wraps them in a [`AppData`] struct that is then returned
 pub fn setup() -> AppData {
     // Only load dotenv in development

--- a/create-rust-app/src/lib.rs
+++ b/create-rust-app/src/lib.rs
@@ -39,13 +39,28 @@ pub use mailer::Mailer;
 // extern crate diesel_migrations;
 
 #[derive(Clone)]
+/// 
 pub struct AppData {
+    /// wrapper for SMTP mailing server accessed by chosen web framework
+    /// 
+    /// see [`Mailer`]
     pub mailer: Mailer,
+    /// db agnostic wrapper for databases accessed by chosen web framework
+    /// 
+    /// see [`Database`]
     pub database: Database,
     #[cfg(feature = "plugin_storage")]
+    /// wrapper for Amazon S3 cloud file storage service accessed by chosen web framework
+    /// 
+    /// see [`Storage`]
     pub storage: storage::Storage,
 }
 
+/// ensures required environment variables are present,
+///  
+/// initialize a [`Mailer`], [`Database`], and [`Storage`] (is `Storage` plugin was enabled ("plugin_storage" feature enabled))
+/// 
+/// and wraps them in a [`AppData`] struct that is then returned
 pub fn setup() -> AppData {
     // Only load dotenv in development
     #[cfg(debug_assertions)]
@@ -82,6 +97,7 @@ pub fn setup() -> AppData {
 use poem;
 
 #[cfg(feature = "backend_poem")]
+/// TODO: documentation
 pub async fn not_found(_: poem::error::NotFoundError) -> poem::Response {
     let json = serde_json::json!({
         "success": false,

--- a/create-rust-app/src/logger.rs
+++ b/create-rust-app/src/logger.rs
@@ -1,21 +1,26 @@
 use poem::{async_trait, Endpoint, IntoResponse, Middleware, Request, Response, Result};
 
+/// Logger middleware that provides similar functionality as [`actix_web::middleware::Logger`] 
+/// for the poem backend
 pub struct Logger;
 
 impl<E: Endpoint> Middleware<E> for Logger {
     type Output = LogImpl<E>;
 
+    /// TODO: documentation
     fn transform(&self, ep: E) -> Self::Output {
         LogImpl(ep)
     }
 }
 
+/// TODO: documentation
 pub struct LogImpl<E>(E);
 
 #[async_trait]
 impl<E: Endpoint> Endpoint for LogImpl<E> {
     type Output = Response;
 
+    /// TODO: documentation
     async fn call(&self, req: Request) -> Result<Self::Output> {
         println!(">  REQUEST: {}", req.uri().path());
         let res = self.0.call(req).await;

--- a/create-rust-app/src/logger.rs
+++ b/create-rust-app/src/logger.rs
@@ -20,7 +20,7 @@ pub struct LogImpl<E>(E);
 impl<E: Endpoint> Endpoint for LogImpl<E> {
     type Output = Response;
 
-    /// TODO: documentation
+    /// Logs requests recieved by the server, as well as the associated responses
     async fn call(&self, req: Request) -> Result<Self::Output> {
         println!(">  REQUEST: {}", req.uri().path());
         let res = self.0.call(req).await;

--- a/create-rust-app/src/logger.rs
+++ b/create-rust-app/src/logger.rs
@@ -1,6 +1,6 @@
 use poem::{async_trait, Endpoint, IntoResponse, Middleware, Request, Response, Result};
 
-/// Logger middleware that provides similar functionality as [`actix_web::middleware::Logger`] 
+/// Logger middleware that provides similar functionality as [`actix_web::middleware::Logger`]
 /// for the poem backend
 pub struct Logger;
 

--- a/create-rust-app/src/mailer.rs
+++ b/create-rust-app/src/mailer.rs
@@ -7,34 +7,34 @@ use lettre::{SmtpTransport, Transport};
 /// struct used to handle sending emails
 pub struct Mailer {
     /// the email address emails should be sent from
-    /// 
+    ///
     /// set by the `SMTP_FROM_ADDRESS` environment variable
     pub from_address: String,
     /// the smtp server to connect to for purposes of sending emails
-    /// 
+    ///
     /// set by the `SMTP_SERVER` environment variable
     pub smtp_server: String,
     /// username used to log into `SMTP_SERVER`
-    /// 
+    ///
     /// set by the `SMTP_USERNAME` environment variable
     pub smtp_username: String,
     /// the password used to log into `SMTP_SERVER`
-    /// 
+    ///
     /// set by the `SMTP_PASSWORD' environment variable
     pub smtp_password: String,
     /// whether or not emails should actually be sent when requested
-    /// 
+    ///
     /// it may be useful to set this to false in some devolopment environments
     /// while setting it to true in production
-    /// 
+    ///
     /// set by the `SEND_MAIL` environment variable
     pub actually_send: bool,
 }
 
 impl Mailer {
     /// using information stored in the `SMTP_FROM_ADDRESS`, `SMTP_SERVER`, `SMTP_USERNAME`, `SMTP_PASSWORD`, and `SEND_MAIL`
-    /// environment variables to connect to a remote SMTP server, 
-    /// 
+    /// environment variables to connect to a remote SMTP server,
+    ///
     /// allows webservers to send emails to users for purposes
     /// like marketing, user authentification, etc.
     pub fn new() -> Mailer {
@@ -59,8 +59,8 @@ impl Mailer {
     }
 
     /// checks that the required environment variables are set
-    /// 
-    /// prints messages denoting which, if any, of the required 
+    ///
+    /// prints messages denoting which, if any, of the required
     /// environment variables were not set
     pub fn check_environment_variables() {
         if std::env::var("SMTP_FROM_ADDRESS").is_err() {
@@ -89,10 +89,10 @@ impl Mailer {
     }
 
     /// send an email with the specifified content and subject to the specified user
-    /// 
-    /// will only send an email if the `SEND_MAIL` environment variable was set to true when 
+    ///
+    /// will only send an email if the `SEND_MAIL` environment variable was set to true when
     /// this mailer was initialized.
-    /// 
+    ///
     /// # Arguments
     /// * `to` - a string slice that holds the email address of the intended recipient
     /// * `subject` - subject field of the email

--- a/create-rust-app/src/mailer.rs
+++ b/create-rust-app/src/mailer.rs
@@ -4,15 +4,39 @@ use lettre::transport::stub::StubTransport;
 use lettre::{SmtpTransport, Transport};
 
 #[derive(Clone)]
+/// struct used to handle sending emails from
 pub struct Mailer {
+    /// the email address emails should be sent from
+    /// 
+    /// set by the `SMTP_FROM_ADDRESS` environment variable
     pub from_address: String,
+    /// the smtp server to connect to for purposes of sending emails
+    /// 
+    /// set by the `SMTP_SERVER` environment variable
     pub smtp_server: String,
+    /// username used to log into `SMTP_SERVER`
+    /// 
+    /// set by the `SMTP_USERNAME` environment variable
     pub smtp_username: String,
+    /// the password used to log into `SMTP_SERVER`
+    /// 
+    /// set by the `SMTP_PASSWORD' environment variable
     pub smtp_password: String,
+    /// whether or not emails should actually be sent when requested
+    /// 
+    /// it may be useful to set this to false in some devolopment environments
+    /// while setting it to true in production
+    /// 
+    /// set by the `SEND_MAIL` environment variable
     pub actually_send: bool,
 }
 
 impl Mailer {
+    /// using information stored in the `SMTP_FROM_ADDRESS`, `SMTP_SERVER`, `SMTP_USERNAME`, `SMTP_PASSWORD`, and `SEND_MAIL`
+    /// environment variables to connect to a remote SMTP server, 
+    /// 
+    /// allows webservers to send emails to users for purposes
+    /// like marketing, user authentification, etc.
     pub fn new() -> Mailer {
         Mailer::check_environment_variables();
 
@@ -34,6 +58,10 @@ impl Mailer {
         };
     }
 
+    /// checks that the required environment variables are set
+    /// 
+    /// prints messages denoting which, if any, of the required 
+    /// environment variables were not set
     pub fn check_environment_variables() {
         if std::env::var("SMTP_FROM_ADDRESS").is_err() {
             println!("Note: Mailing disabled; 'SMTP_FROM_ADDRESS' not set.");
@@ -60,6 +88,16 @@ impl Mailer {
         }
     }
 
+    /// send an email with the specifified content and subject to the specified user
+    /// 
+    /// will only send an email if the `SEND_MAIL` environment variable was set to true when 
+    /// this mailer was initialized.
+    /// 
+    /// # Arguments
+    /// * `to` - a string slice that holds the email address of the intended recipient
+    /// * `subject` - subject field of the email
+    /// * `text` - text content of the email
+    /// * `html` - html content of the email
     pub fn send(&self, to: &str, subject: &str, text: &str, html: &str) {
         let email = Message::builder()
             .to(to.parse().unwrap())

--- a/create-rust-app/src/mailer.rs
+++ b/create-rust-app/src/mailer.rs
@@ -4,7 +4,7 @@ use lettre::transport::stub::StubTransport;
 use lettre::{SmtpTransport, Transport};
 
 #[derive(Clone)]
-/// struct used to handle sending emails from
+/// struct used to handle sending emails
 pub struct Mailer {
     /// the email address emails should be sent from
     /// 

--- a/create-rust-app/src/util/actix_web_utils.rs
+++ b/create-rust-app/src/util/actix_web_utils.rs
@@ -30,7 +30,7 @@ async fn render_spa_handler(
     template_response(content)
 }
 
-/// takes a request to say, www.you_webapp.com/foo/bar and looks in the ./backend/views folder
+/// takes a request to, say, www.you_webapp.com/foo/bar and looks in the ./backend/views folder
 /// for a html file/template at the matching path (in this case, ./foo/bar.html),
 /// defaults to index.html
 /// 
@@ -39,7 +39,7 @@ async fn render_spa_handler(
 /// 
 /// then, that compiled html is sent to the client
 /// 
-/// TODO: that is what should be happening, but in the generated code there is no ./frontend/dist/manifest.json which should cause errors but doesn't
+/// NOTE the frontend/dist/manifest.json file referenced is generated in the frontend when it compiles
 pub async fn render_views(req: HttpRequest) -> HttpResponse {
     let path = req.path();
 

--- a/create-rust-app/src/util/net.rs
+++ b/create-rust-app/src/util/net.rs
@@ -1,5 +1,6 @@
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6, TcpListener, ToSocketAddrs};
 
+/// binds a [`TcpListener`] to the given [`addr`](`ToSocketAddrs`)
 fn test_bind<A: ToSocketAddrs>(addr: A) -> bool {
     match TcpListener::bind(addr).map(|t| t.local_addr().is_ok()) {
         Ok(result) => result,
@@ -7,6 +8,8 @@ fn test_bind<A: ToSocketAddrs>(addr: A) -> bool {
     }
 }
 
+/// is the given port free 
+/// TODO: free on what server?
 pub fn is_port_free(port: u16) -> bool {
     let ipv4 = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port);
     let ipv6 = SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, port, 0, 0);

--- a/create-rust-app/src/util/net.rs
+++ b/create-rust-app/src/util/net.rs
@@ -8,8 +8,7 @@ fn test_bind<A: ToSocketAddrs>(addr: A) -> bool {
     }
 }
 
-/// is the given port free 
-/// TODO: free on what server?
+/// is the given port free on this machine
 pub fn is_port_free(port: u16) -> bool {
     let ipv4 = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port);
     let ipv6 = SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, port, 0, 0);

--- a/create-rust-app/src/util/poem_utils.rs
+++ b/create-rust-app/src/util/poem_utils.rs
@@ -27,11 +27,19 @@ pub fn render_single_page_application(view: &str) -> AddDataEndpoint<Route, Sing
 #[handler]
 async fn render_spa_handler(spa_info: Data<&SinglePageApplication>) -> impl IntoResponse {
     let content = TEMPLATES
-        .render(spa_info.view_name.as_str(), &Context::new())
-        .unwrap();
+    .render(spa_info.view_name.as_str(), &Context::new())
+    .unwrap();
     template_response(content)
 }
 
+/// takes a request to, say, www.you_webapp.com/foo/bar and looks in the ./backend/views folder
+/// for a html file/template at the matching path (in this case, ./foo/bar.html),
+/// defaults to index.html
+/// 
+/// then, your frontend (all the css files, scripts, etc. in your frontend's vite manifest (at ./frontend/dist/manifest.json))
+/// will be compiled and injected into the template wherever `{{ bundle(name="index.tsx") }}` is (the `index.tsx` can be any .tsx file in ./frontend/bundles)
+/// 
+/// then, that compiled html is sent to the client
 #[handler]
 pub async fn render_views(uri: &Uri) -> impl IntoResponse {
     let path = uri.path();

--- a/create-rust-app/src/util/poem_utils.rs
+++ b/create-rust-app/src/util/poem_utils.rs
@@ -11,7 +11,9 @@ use super::template_utils::SinglePageApplication;
 ///  view: the template which renders the app
 ///
 ///  Full example (to render the `views/spa.html` template):
+/// ```
 ///  app = app.nest("/my-spa", create_rust_app::render_single_page_application("spa.html"));
+/// ```
 pub fn render_single_page_application(view: &str) -> AddDataEndpoint<Route, SinglePageApplication> {
     let view = view.strip_prefix("/").unwrap_or(view);
 

--- a/create-rust-app/src/util/template_utils.rs
+++ b/create-rust-app/src/util/template_utils.rs
@@ -3,11 +3,14 @@ use std::collections::HashMap;
 use tera::Tera;
 
 #[derive(Clone)]
+/// structure to represent the view (singular) of a single page application
 pub struct SinglePageApplication {
     pub view_name: String,
 }
 
 lazy_static! {
+    /// all the Templates (html files) included in backend/views/..., uses Tera to bundle the frontend into the template
+    /// TODO: ensure this is accurate documentation
     pub static ref TEMPLATES: Tera = {
         let mut tera = match Tera::new("backend/views/**/*.html") {
             Ok(t) => t,
@@ -26,7 +29,9 @@ lazy_static! {
     };
 }
 
+/// default html template for the webapp
 pub const DEFAULT_TEMPLATE: &'static str = "index.html";
+/// given a http request path, get the associated html TEMPLATE
 pub fn to_template_name(request_path: &str) -> &'_ str {
     let request_path = request_path.strip_prefix("/").unwrap();
     return if request_path.eq("") {
@@ -116,19 +121,19 @@ impl tera::Function for InjectBundle {
 
 #[derive(serde::Deserialize)]
 pub struct ViteManifestEntry {
-    // Script content to load for this entry
+    /// Script content to load for this entry
     file: String,
 
-    // Script content to lazy-load for this entry
+    /// Script content to lazy-load for this entry
     dynamicImports: Option<Vec<String>>, // using `import(..)`
 
-    // Style content to load for this entry
+    /// Style content to load for this entry
     css: Option<Vec<String>>, // using import '*.css'
 
-    // If true, eager-load this content
+    /// If true, eager-load this content
     isEntry: Option<bool>,
 
-    // If true, lazy-load this content
+    /// If true, lazy-load this content
     isDynamicEntry: Option<bool>, // src: String, /* => not necessary :) */
                                   // assets: Option<Vec<String>>, /* => these will be served by the server! */
 }

--- a/create-rust-app_cli/src/content/project.rs
+++ b/create-rust-app_cli/src/content/project.rs
@@ -349,8 +349,8 @@ pub fn create(project_name: &str, creation_options: CreationOptions) -> Result<(
         r#"chrono = { version = "0.4.19", features = ["serde"] }"#,
     )?;
     // todo: move these deps to the helper crate (./create-rust-app/Cargo.toml) behind feature flags
-    add_dependency(&project_dir, "tsync", r#"tsync = "1""#)?;
-    add_dependency(&project_dir, "dsync", r#"dsync = "0""#)?;
+    add_dependency(&project_dir, "tsync", r#"tsync = "1.6.0""#)?;
+    add_dependency(&project_dir, "dsync", r#"dsync = "0.0.5""#)?;
     add_dependency(
         &project_dir,
         "diesel",

--- a/create-rust-app_cli/src/main.rs
+++ b/create-rust-app_cli/src/main.rs
@@ -129,7 +129,9 @@ fn create_project() -> anyhow::Result<()> {
     }
 
     logger::message("Please select plugins for your new project:");
-    logger::message("Use UP/DOWN arrows to navigate, SPACE to enable/disable a plugin, and ENTER to confirm.");
+    logger::message(
+        "Use UP/DOWN arrows to navigate, SPACE to enable/disable a plugin, and ENTER to confirm.",
+    );
 
     let items = vec![
         "Authentication Plugin: local email-based authentication",


### PR DESCRIPTION
Attempts to add documentation to the create-rust-app library that can be parsed by / published to [docs.rs](https://docs.rs/)

even some things marked as "complete" may include TODOs for things I don't understand or don't have the will to document

### Progress

#### library root
- [x] mailer.rs 
- [x] logger.rs 
- [x] lib.rs 

#### database module 
- [x] mod.rs 

#### auth module
- [x] endpoints submodule
- [x] extractors submodule
- [x] mail submodule (Documentation not needed, this is a private submodule)
- [x] permissions submodule
- [x] schema submodule (Documentation not needed)
- [x] controller.rs
- [x] mod.rs
- [x] user_session.rs 
- [x] user.rs


#### util module
- [x] actix_web_utils.rs
- [x] mod.rs (Docs not needed)
- [x] net.rs
- [x] poem_utils.rs
- [x] template_utils.rs (not public facing)


### not started, and may not do:
#### dev module
I don't see much point documenting this as the Dev panel still hasn't been implemented
- [ ] endpoints submodule
- [ ] controller.rs
- [ ] mod.rs

#### storage module
I personally have little motivation to document this as it's not a feature I see myself using soon, selfish I know, but I'm busy
- [_] schema submodule
- [_] attachment_blob.rs
- [_] attachment.rs
- [_] mod.rs
- [_] schema.rs
