### PR TITLE
Remove useless argonautica dependency from service_poem.rs fix #80

### DIFF
--- a/create-rust-app/src/dev/endpoints/service_poem.rs
+++ b/create-rust-app/src/dev/endpoints/service_poem.rs
@@ -1,4 +1,3 @@
-use argonautica::config::Version::_0x10;
 use poem::{
     get, handler,
     http::StatusCode,


### PR DESCRIPTION
Fixes #80 

 The argonautica dependency didn't seem to be used anywhere in the file so I just removed it.