### PR TITLE
bring Auth guard into compliance with RFC-6750 (fixes #87)

### DIFF
--- a/create-rust-app/src/auth/extractors/auth_actixweb.rs
+++ b/create-rust-app/src/auth/extractors/auth_actixweb.rs
@@ -100,8 +100,14 @@ impl FromRequest for Auth {
 
         let access_token_str = auth_header_opt.unwrap().to_str().unwrap_or("");
 
+        if !access_token_str.starts_with("Bearer ") { 
+            return ready(Err(AuthError {
+                reason: "Invalid authorization header".to_string(),
+            }));
+        }
+
         let access_token = decode::<AccessTokenClaims>(
-            access_token_str,
+            access_token_str.trim_start_matches("Bearer "),
             &DecodingKey::from_secret(std::env::var("SECRET_KEY").unwrap().as_ref()),
             &Validation::default(),
         );

--- a/create-rust-app/src/auth/extractors/auth_poem.rs
+++ b/create-rust-app/src/auth/extractors/auth_poem.rs
@@ -70,8 +70,15 @@ impl<'a> FromRequest<'a> for Auth {
 
         let access_token_str = auth_header_opt.unwrap().to_str().unwrap_or("");
 
+        if !access_token_str.starts_with("Bearer ") { 
+            return Err(Error::from_string(
+                "Invalid authorization header",
+                StatusCode::UNAUTHORIZED,
+            ));
+        }
+
         let access_token = decode::<AccessTokenClaims>(
-            access_token_str,
+            access_token_str.trim_start_matches("Bearer "),
             &DecodingKey::from_secret(std::env::var("SECRET_KEY").unwrap().as_ref()),
             &Validation::default(),
         );

--- a/create-rust-app_cli/src/qsync/hook.rs
+++ b/create-rust-app_cli/src/qsync/hook.rs
@@ -240,7 +240,7 @@ impl Hook {
 }}"#,
                 variables = self.build_vars_string(),
                 authorization_header = if self.uses_auth {
-                    "'Authorization': `${auth.accessToken}`,\n              "
+                    "'Authorization': `Bearer ${auth.accessToken}`,\n              "
                 } else {
                     ""
                 },
@@ -277,7 +277,7 @@ impl Hook {
 }}"#,
                 variables = self.build_vars_string(),
                 authorization_header = if self.uses_auth {
-                    "'Authorization': `${auth.accessToken}`,\n              "
+                    "'Authorization': `Bearer ${auth.accessToken}`,\n              "
                 } else {
                     ""
                 },


### PR DESCRIPTION
fixes #87 

Add check to ensure Authorization header has proper prefix, then trim that prefix to extract the actual token