### PR TITLE
Add rudementry email template support, available with the auth plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,6 +1390,7 @@ dependencies = [
  "diesel_derives",
  "diesel_migrations",
  "dotenv",
+ "dyn-clone",
  "env_logger",
  "fang",
  "futures",
@@ -1719,6 +1720,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "either"

--- a/create-rust-app/Cargo.toml
+++ b/create-rust-app/Cargo.toml
@@ -8,7 +8,13 @@ readme = "../README.md"
 repository = "https://github.com/Wulf/create-rust-app"
 license = "MIT OR Apache-2.0"
 keywords = ["react", "typescript", "generation", "backend", "frontend"]
-categories = ["command-line-utilities", "development-tools", "web-programming", "config", "database"]
+categories = [
+  "command-line-utilities",
+  "development-tools",
+  "web-programming",
+  "config",
+  "database",
+]
 
 [dependencies]
 ##
@@ -17,10 +23,14 @@ categories = ["command-line-utilities", "development-tools", "web-programming", 
 dotenv = "0.15.0" # + plugin_dev
 serde_json = "1.0.93"
 lettre = "0.10.2"
-tera = { version="1.17.0" }
-lazy_static = { version="1.4.0" }
+tera = { version = "1.17.0" }
+lazy_static = { version = "1.4.0" }
 serde = { version = "1.0.152", features = ["derive"] }
-diesel = { version="2.0.0-rc.1", default-features = false, features = ["uuid", "r2d2", "chrono"] } # + plugin_dev, plugin_auth
+diesel = { version = "2.0.0-rc.1", default-features = false, features = [
+  "uuid",
+  "r2d2",
+  "chrono",
+] } # + plugin_dev, plugin_auth
 once_cell = "1.17.1"
 
 ##
@@ -35,83 +45,150 @@ libsqlite3-sys = { version = "0.25", optional = true, features = ["bundled"] }
 ##
 
 # plugin_auth
-rust-argon2 = { optional=true, version="1.0" }
-rand = { optional=true, version="0.8.5" }
-jsonwebtoken = { optional=true, version="8.2.0" }
-tsync = { optional=true, version="1.6.0" }
-chrono = { optional=true, version = "0.4.23", default-features = false, features = ["clock", "serde"] }
+rust-argon2 = { optional = true, version = "1.0" }
+rand = { optional = true, version = "0.8.5" }
+jsonwebtoken = { optional = true, version = "8.2.0" }
+tsync = { optional = true, version = "1.6.0" }
+chrono = { optional = true, version = "0.4.23", default-features = false, features = [
+  "clock",
+  "serde",
+] }
+dyn-clone = { optional = true, version = "1.0" } # needed to allow the Mailer struct to be cloned
 
 # plugin_dev
-diesel_migrations = { optional=true, version="2.0.0" }
-cargo_metadata = { optional=true, version="0.15.2" }
-watchexec = { optional=true, version="2.2.0" }
+diesel_migrations = { optional = true, version = "2.0.0" }
+cargo_metadata = { optional = true, version = "0.15.2" }
+watchexec = { optional = true, version = "2.2.0" }
 #### tracing = { optional=true, version="0.1" }
 #### tracing-subscriber = { optional=true, version="0.3.16", features=["env-filter"] }
-reqwest = { optional=true, version="0.11.13" }
-clearscreen = { optional=true, version="2.0.0" }
-open = { optional=true, version="3.2.0" }
-cargo_toml = { optional=true, version = "0.14.0" }
+reqwest = { optional = true, version = "0.11.13" }
+clearscreen = { optional = true, version = "2.0.0" }
+open = { optional = true, version = "3.2.0" }
+cargo_toml = { optional = true, version = "0.14.0" }
 
 # plugin_storage
-aws-config = { optional=true, version="0.14.0" }
-aws-types = { optional=true, version="0.8.0" }
-aws-endpoint = { optional=true, version="0.14.0" }
-aws-sdk-s3 = { optional=true, version="0.8.0" }
-http = { optional=true, version="0.2.6" }
-diesel_derives = { optional=true, version="2.0.1" }
-uuid = { optional=true, version="1.2.2", features=["v4", "serde"] }
-md5 = { optional=true, version="0.7.0" }
-base64 = { optional=true, version="0.21.0" }
+aws-config = { optional = true, version = "0.14.0" }
+aws-types = { optional = true, version = "0.8.0" }
+aws-endpoint = { optional = true, version = "0.14.0" }
+aws-sdk-s3 = { optional = true, version = "0.8.0" }
+http = { optional = true, version = "0.2.6" }
+diesel_derives = { optional = true, version = "2.0.1" }
+uuid = { optional = true, version = "1.2.2", features = ["v4", "serde"] }
+md5 = { optional = true, version = "0.7.0" }
+base64 = { optional = true, version = "0.21.0" }
 
 # plugin_utoipa dependencies
-utoipa = { optional=true, version="3", features=["actix_extras", "chrono", "openapi_extensions"] }
-utoipa-swagger-ui = { optional=true, version="3", features=["actix-web"]}
+utoipa = { optional = true, version = "3", features = [
+  "actix_extras",
+  "chrono",
+  "openapi_extensions",
+] }
+utoipa-swagger-ui = { optional = true, version = "3", features = ["actix-web"] }
 
 # plugin_tasks
-fang = { optional=true, version = "0.10.3" }
+fang = { optional = true, version = "0.10.3" }
 
 ##
 ## BACKENDS
 ##
 
 # poem dependencies
-poem = { optional=true, version="1.3.52", features=["anyhow", "cookie", "static-files"] }
+poem = { optional = true, version = "1.3.52", features = [
+  "anyhow",
+  "cookie",
+  "static-files",
+] }
 
 # actix_web dependencies
-actix-multipart = { optional=true, version="0.4.0" }
-actix-files = { optional=true, version="0.6.2" }
-actix-http = { optional=true, version="3.0.4" }
-actix-web = { optional=true, version="4.2.1" }
-actix-web-httpauth = { optional=true, version="0.8.0" }
-derive_more = { optional=true, version="0.99.17" }
-futures = { optional=true, version="0.3.25" }
-env_logger = { optional=true, version= "0.10.0" }
+actix-multipart = { optional = true, version = "0.4.0" }
+actix-files = { optional = true, version = "0.6.2" }
+actix-http = { optional = true, version = "3.0.4" }
+actix-web = { optional = true, version = "4.2.1" }
+actix-web-httpauth = { optional = true, version = "0.8.0" }
+derive_more = { optional = true, version = "0.99.17" }
+futures = { optional = true, version = "0.3.25" }
+env_logger = { optional = true, version = "0.10.0" }
 
 # axum dependencies (not yet released; only used for plugin_dev)
 
-axum = { optional=true, version="0.6.1" }
+axum = { optional = true, version = "0.6.1" }
 
 ##
 ## MISC - here, we list deps which are required by multiple features but are not required in all configurations
 ##
 
-mime_guess = { optional=true, version="2.0.4" } # backend_poem, plugin_storage
-anyhow = { optional=true, version="1.0.57" } # backend_poem, plugin_auth, plugin_dev
-tokio = { optional=true, version = "1", features = ["full"] } # backend_poem, backend_axum, plugin_storage
+mime_guess = { optional = true, version = "2.0.4" } # backend_poem, plugin_storage
+anyhow = { optional = true, version = "1.0.57" } # backend_poem, plugin_auth, plugin_dev
+tokio = { optional = true, version = "1", features = [
+  "full",
+] } # backend_poem, backend_axum, plugin_storage
 async-priority-channel = "0.1.0"
-futures-util = { optional=true, version = "0.3.25" } # plugin_dev, TODO:plugin_storage?
+futures-util = { optional = true, version = "0.3.25" } # plugin_dev, TODO:plugin_storage?
 
 [features]
-default = ["backend_actix-web", "database_postgres", "plugin_auth", "plugin_container", "plugin_dev", "plugin_graphql", "plugin_storage", "plugin_utoipa"]
-plugin_dev = ["backend_axum", "cargo_toml", "open", "reqwest", "anyhow", "clearscreen", "watchexec", "cargo_metadata", "diesel_migrations", "futures-util"]
+default = [
+  "backend_actix-web",
+  "database_postgres",
+  "plugin_auth",
+  "plugin_container",
+  "plugin_dev",
+  "plugin_graphql",
+  "plugin_storage",
+  "plugin_utoipa",
+]
+plugin_dev = [
+  "backend_axum",
+  "cargo_toml",
+  "open",
+  "reqwest",
+  "anyhow",
+  "clearscreen",
+  "watchexec",
+  "cargo_metadata",
+  "diesel_migrations",
+  "futures-util",
+]
 plugin_container = []
-plugin_auth = ["anyhow", "rust-argon2", "rand", "jsonwebtoken", "chrono", "tsync"]
-plugin_storage = [ "aws-config", "aws-types", "aws-endpoint", "aws-sdk-s3", "tokio", "http", "diesel_derives", "uuid", "md5", "mime_guess", "base64" ] # note: might need to add "futures-util"?
+plugin_auth = [
+  "anyhow",
+  "rust-argon2",
+  "rand",
+  "jsonwebtoken",
+  "chrono",
+  "tsync",
+  "dyn-clone",
+]
+plugin_storage = [
+  "aws-config",
+  "aws-types",
+  "aws-endpoint",
+  "aws-sdk-s3",
+  "tokio",
+  "http",
+  "diesel_derives",
+  "uuid",
+  "md5",
+  "mime_guess",
+  "base64",
+] # note: might need to add "futures-util"?
 plugin_graphql = []
 plugin_utoipa = ["utoipa", "utoipa-swagger-ui", "backend_actix-web"]
 plugin_tasks = ["fang"]
 backend_poem = ["poem", "anyhow", "mime_guess", "tokio"]
-backend_actix-web = ["actix-web", "actix-http", "actix-files", "actix-multipart", "actix-web-httpauth","derive_more", "futures", "env_logger"]
+backend_actix-web = [
+  "actix-web",
+  "actix-http",
+  "actix-files",
+  "actix-multipart",
+  "actix-web-httpauth",
+  "derive_more",
+  "futures",
+  "env_logger",
+]
 backend_axum = ["axum", "axum/ws", "tokio"]
-database_sqlite = ["diesel/sqlite", "diesel/returning_clauses_for_sqlite_3_35", "libsqlite3-sys/bundled"]
+database_sqlite = [
+  "diesel/sqlite",
+  "diesel/returning_clauses_for_sqlite_3_35",
+  "libsqlite3-sys/bundled",
+]
 database_postgres = ["diesel/postgres"]

--- a/create-rust-app/src/auth/controller.rs
+++ b/create-rust-app/src/auth/controller.rs
@@ -529,11 +529,9 @@ pub fn register(
     )
     .unwrap();
 
-    mail::auth_register::send(
-        mailer,
-        &user.email,
-        &format!("http://localhost:3000/activate?token={token}"),
-    );
+    mailer
+        .templates
+        .send_register(mailer, &user.email, &format!("activate?token={token}"));
 
     Ok(())
 }
@@ -598,7 +596,7 @@ pub fn activate(
         return Err((500, "Could not activate user."));
     }
 
-    mail::auth_activated::send(mailer, &user.email);
+    mailer.templates.send_activated(mailer, &user.email);
 
     Ok(())
 }
@@ -642,11 +640,15 @@ pub fn forgot_password(
         )
         .unwrap();
 
-        let link = &format!("http://localhost:3000/reset?token={reset_token}");
-        mail::auth_recover_existent_account::send(mailer, &user.email, link);
+        let link = &format!("reset?token={reset_token}");
+        mailer
+            .templates
+            .send_recover_existent_account(mailer, &user.email, link);
     } else {
-        let link = &"http://localhost:300/register".to_string();
-        mail::auth_recover_nonexistent_account::send(mailer, &item.email, link);
+        let link = &"register".to_string();
+        mailer
+            .templates
+            .send_recover_nonexistent_account(mailer, &item.email, link);
     }
 
     Ok(())
@@ -718,7 +720,7 @@ pub fn change_password(
         return Err((500, "Could not update password"));
     }
 
-    mail::auth_password_changed::send(mailer, &user.email);
+    mailer.templates.send_password_changed(mailer, &user.email);
 
     Ok(())
 }
@@ -794,7 +796,7 @@ pub fn reset_password(
         return Err((500, "Could not update password"));
     }
 
-    mail::auth_password_reset::send(mailer, &user.email);
+    mailer.templates.send_password_reset(mailer, &user.email);
 
     Ok(())
 }

--- a/create-rust-app/src/auth/mail/auth_activated.rs
+++ b/create-rust-app/src/auth/mail/auth_activated.rs
@@ -13,9 +13,9 @@ Your account has been activated!
     .to_string();
     let html = r#"
 <p>(This is an automated message.)</p>
-<br>
+
 <p>Hello,</p>
-<br>
+
 <p>Your account has been activated!</p>
 "#
     .to_string();

--- a/create-rust-app/src/auth/mail/auth_activated.rs
+++ b/create-rust-app/src/auth/mail/auth_activated.rs
@@ -2,7 +2,7 @@ use crate::Mailer;
 
 #[allow(dead_code)]
 pub fn send(mailer: &Mailer, to_email: &str) {
-    let subject = "Account activated)";
+    let subject = "Account activated";
     let text = r#"
 (This is an automated message.)
 
@@ -12,11 +12,11 @@ Your account has been activated!
 "#
     .to_string();
     let html = r#"
-(This is an automated message.)
-
-Hello,
-
-Your account has been activated!
+<p>(This is an automated message.)</p>
+<br>
+<p>Hello,</p>
+<br>
+<p>Your account has been activated!</p>
 "#
     .to_string();
 

--- a/create-rust-app/src/auth/mail/auth_password_changed.rs
+++ b/create-rust-app/src/auth/mail/auth_password_changed.rs
@@ -13,9 +13,9 @@ Your password was changed successfully!
     .to_string();
     let html = r#"
 <p>(This is an automated message.)</p>
-<br>
+
 <p>Hello,</p>
-<br>
+
 <p>Your password was changed successfully!</p>
 "#
     .to_string();

--- a/create-rust-app/src/auth/mail/auth_password_changed.rs
+++ b/create-rust-app/src/auth/mail/auth_password_changed.rs
@@ -2,7 +2,7 @@ use crate::Mailer;
 
 #[allow(dead_code)]
 pub fn send(mailer: &Mailer, to_email: &str) {
-    let subject = "Your password was changed)";
+    let subject = "Your password was changed";
     let text = r#"
 (This is an automated message.)
 
@@ -12,11 +12,11 @@ Your password was changed successfully!
 "#
     .to_string();
     let html = r#"
-(This is an automated message.)
-
-Hello,
-
-Your password was changed successfully!
+<p>(This is an automated message.)</p>
+<br>
+<p>Hello,</p>
+<br>
+<p>Your password was changed successfully!</p>
 "#
     .to_string();
 

--- a/create-rust-app/src/auth/mail/auth_password_reset.rs
+++ b/create-rust-app/src/auth/mail/auth_password_reset.rs
@@ -14,9 +14,9 @@ Your password was successfully reset!
 
     let html = r#"
 <p>(This is an automated message.)</p>
-<br>
+
 <p>Hello,</p>
-<br>
+
 <p>Your password was successfully reset!</p>
 "#
     .to_string();

--- a/create-rust-app/src/auth/mail/auth_password_reset.rs
+++ b/create-rust-app/src/auth/mail/auth_password_reset.rs
@@ -2,7 +2,7 @@ use crate::Mailer;
 
 #[allow(dead_code)]
 pub fn send(mailer: &Mailer, to_email: &str) {
-    let subject = "Your password was reset)";
+    let subject = "Your password was reset";
     let text = r#"
 (This is an automated message.)
 
@@ -13,11 +13,11 @@ Your password was successfully reset!
     .to_string();
 
     let html = r#"
-(This is an automated message.)
-
-Hello,
-
-Your password was successfully reset!
+<p>(This is an automated message.)</p>
+<br>
+<p>Hello,</p>
+<br>
+<p>Your password was successfully reset!</p>
 "#
     .to_string();
 

--- a/create-rust-app/src/auth/mail/auth_recover_existent_account.rs
+++ b/create-rust-app/src/auth/mail/auth_recover_existent_account.rs
@@ -18,11 +18,11 @@ Please visit this link to reset your password:
     let html = format!(
         r#"
 <p>(This is an automated message.)</p>
-<br>
+
 <p>Hello,</p>
-<br>
-<p>Someone requested a password reset for the account associated with this email.</p>
-<p>Please visit this link to reset your password:</p>
+
+<p>Someone requested a password reset for the account associated with this email.
+Please visit this link to reset your password:</p>
 <p><a href="{link}">{link}</a></p>
 <p>(valid for 24 hours)</p>
 "#

--- a/create-rust-app/src/auth/mail/auth_recover_existent_account.rs
+++ b/create-rust-app/src/auth/mail/auth_recover_existent_account.rs
@@ -2,7 +2,7 @@ use crate::Mailer;
 
 #[allow(dead_code)]
 pub fn send(mailer: &Mailer, to_email: &str, link: &str) {
-    let subject = "Reset Password Instructions)";
+    let subject = "Reset Password Instructions";
     let text = format!(
         r#"
 (This is an automated message.)
@@ -17,14 +17,14 @@ Please visit this link to reset your password:
     );
     let html = format!(
         r#"
-(This is an automated message.)
-
-Hello,
-
-Someone requested a password reset for the account associated with this email.
-Please visit this link to reset your password:
-{link}
-(valid for 24 hours)
+<p>(This is an automated message.)</p>
+<br>
+<p>Hello,</p>
+<br>
+<p>Someone requested a password reset for the account associated with this email.</p>
+<p>Please visit this link to reset your password:</p>
+<p><a href="{link}">{link}</a></p>
+<p>(valid for 24 hours)</p>
 "#
     );
 

--- a/create-rust-app/src/auth/mail/auth_recover_nonexistent_account.rs
+++ b/create-rust-app/src/auth/mail/auth_recover_nonexistent_account.rs
@@ -17,11 +17,11 @@ If this was intentional, you can register for a new account using the link below
     let html = format!(
         r#"
 <p>(This is an automated message.)</p>
-<br>
+
 <p>Hello,<p>
-<br>
-<p>Someone requested a password reset for the account associated with this email, but no account exists!</p>
-<p>If this was intentional, you can register for a new account using the link below:</p>
+
+<p>Someone requested a password reset for the account associated with this email, but no account exists!
+If this was intentional, you can register for a new account using the link below:</p>
 <p><a href="{link}">{link}</a></p>
 "#
     );

--- a/create-rust-app/src/auth/mail/auth_recover_nonexistent_account.rs
+++ b/create-rust-app/src/auth/mail/auth_recover_nonexistent_account.rs
@@ -2,7 +2,7 @@ use crate::Mailer;
 
 #[allow(dead_code)]
 pub fn send(mailer: &Mailer, to_email: &str, link: &str) {
-    let subject = "Reset Password Instructions)";
+    let subject = "Reset Password Instructions";
     let text = format!(
         r#"
 (This is an automated message.)
@@ -16,13 +16,13 @@ If this was intentional, you can register for a new account using the link below
     );
     let html = format!(
         r#"
-(This is an automated message.)
-
-Hello,
-
-Someone requested a password reset for the account associated with this email, but no account exists!
-If this was intentional, you can register for a new account using the link below:
-{link}
+<p>(This is an automated message.)</p>
+<br>
+<p>Hello,<p>
+<br>
+<p>Someone requested a password reset for the account associated with this email, but no account exists!</p>
+<p>If this was intentional, you can register for a new account using the link below:</p>
+<p><a href="{link}">{link}</a></p>
 "#
     );
 

--- a/create-rust-app/src/auth/mail/auth_register.rs
+++ b/create-rust-app/src/auth/mail/auth_register.rs
@@ -16,9 +16,9 @@ Please follow the link below to complete your registration:
     let html = format!(
         r#"
 <p>(This is an automated message.)</p>
-<br>
+
 <p>Hello,</p>
-<br>
+
 <p>Please follow the link below to complete your registration:</p>
 <p><a href="{link}">{link}</a></p>
 "#

--- a/create-rust-app/src/auth/mail/auth_register.rs
+++ b/create-rust-app/src/auth/mail/auth_register.rs
@@ -2,7 +2,7 @@ use crate::Mailer;
 
 #[allow(dead_code)]
 pub fn send(mailer: &Mailer, to_email: &str, link: &str) {
-    let subject = "Registration Confirmation)";
+    let subject = "Registration Confirmation";
     let text = format!(
         r#"
 (This is an automated message.)
@@ -15,12 +15,12 @@ Please follow the link below to complete your registration:
     );
     let html = format!(
         r#"
-(This is an automated message.)
-
-Hello,
-
-Please follow the link below to complete your registration:
-{link}
+<p>(This is an automated message.)</p>
+<br>
+<p>Hello,</p>
+<br>
+<p>Please follow the link below to complete your registration:</p>
+<p><a href="{link}">{link}</a></p>
 "#
     );
 

--- a/create-rust-app/src/auth/mod.rs
+++ b/create-rust-app/src/auth/mod.rs
@@ -15,7 +15,7 @@ pub mod controller;
 mod endpoints;
 pub use endpoints::*;
 
-mod mail;
+pub(crate) mod mail;
 mod permissions;
 mod schema;
 mod user;

--- a/create-rust-app/src/database/mod.rs
+++ b/create-rust-app/src/database/mod.rs
@@ -1,5 +1,5 @@
-use diesel::PgConnection;
 use diesel::r2d2::{self, ConnectionManager, PooledConnection};
+use diesel::PgConnection;
 use once_cell::sync::OnceCell;
 
 #[cfg(feature = "database_postgres")]

--- a/create-rust-app/src/lib.rs
+++ b/create-rust-app/src/lib.rs
@@ -11,6 +11,9 @@ compile_error!(
 // #[cfg(not(any(feature = "backend_poem", feature = "backend_actix-web")))]
 // compile_error!("Please enable one of the backend features (options: 'backend_actix-web', 'backend-poem')");
 
+#[cfg(feature = "plugin_auth")]
+use mailer::EmailTemplates;
+
 mod util;
 pub use util::*;
 
@@ -67,6 +70,17 @@ pub struct AppData {
     pub storage: Storage,
 }
 
+#[cfg(feature = "plugin_auth")]
+impl AppData {
+    pub fn with_custom_email_templates<T: EmailTemplates + 'static>(
+        mut self,
+        templates: T,
+    ) -> Self {
+        self.mailer = Mailer::new(Box::new(templates));
+        self
+    }
+}
+
 #[cfg(debug_assertions)]
 fn load_env_vars() {
     static START: std::sync::Once = std::sync::Once::new();
@@ -103,7 +117,7 @@ pub fn setup() -> AppData {
     }
 
     AppData {
-        mailer: Mailer::new(),
+        mailer: Mailer::default(),
         database: Database::new(),
         #[cfg(feature = "plugin_storage")]
         storage: Storage::new(),

--- a/create-rust-app/src/lib.rs
+++ b/create-rust-app/src/lib.rs
@@ -11,9 +11,6 @@ compile_error!(
 // #[cfg(not(any(feature = "backend_poem", feature = "backend_actix-web")))]
 // compile_error!("Please enable one of the backend features (options: 'backend_actix-web', 'backend-poem')");
 
-#[cfg(feature = "plugin_auth")]
-use mailer::EmailTemplates;
-
 mod util;
 pub use util::*;
 
@@ -47,6 +44,8 @@ pub use storage::{Attachment, AttachmentBlob, AttachmentData, Storage};
 
 mod mailer;
 pub use mailer::Mailer;
+#[cfg(feature = "plugin_auth")]
+pub use mailer::{DefaultMailTemplates, EmailTemplates};
 
 // #[cfg(debug_assertions)]
 // #[macro_use]

--- a/create-rust-app/src/tasks/mod.rs
+++ b/create-rust-app/src/tasks/mod.rs
@@ -1,6 +1,6 @@
+use crate::Database;
 use fang::Queue;
 use once_cell::sync::OnceCell;
-use crate::Database;
 // re-export setup for tasks
 pub use crate::setup;
 
@@ -13,8 +13,6 @@ pub fn queue() -> &'static Queue {
     QUEUE.get_or_init(|| {
         let db = Database::new();
 
-        Queue::builder()
-            .connection_pool(db.pool.clone())
-            .build()
+        Queue::builder().connection_pool(db.pool.clone()).build()
     })
 }

--- a/create-rust-app_cli/src/content/project.rs
+++ b/create-rust-app_cli/src/content/project.rs
@@ -44,7 +44,10 @@ fn get_current_cra_lib_version() -> String {
     "9".to_string()
 }
 
-fn add_bins_to_cargo_toml(project_dir: &std::path::PathBuf, creations_options: &CreationOptions) -> Result<(), std::io::Error> {
+fn add_bins_to_cargo_toml(
+    project_dir: &std::path::PathBuf,
+    creations_options: &CreationOptions,
+) -> Result<(), std::io::Error> {
     let mut path = std::path::PathBuf::from(project_dir);
     path.push("Cargo.toml");
 
@@ -77,7 +80,10 @@ fn add_bins_to_cargo_toml(project_dir: &std::path::PathBuf, creations_options: &
 
     let updated_toml = toml::to_string(&parsed_toml).unwrap();
 
-    let queue_bin = if creations_options.cra_enabled_features.contains(&"plugin_tasks".to_string()) {
+    let queue_bin = if creations_options
+        .cra_enabled_features
+        .contains(&"plugin_tasks".to_string())
+    {
         r##"
 [[bin]]
 name = "queue"
@@ -115,7 +121,8 @@ path = "backend/main.rs"
 {queue_bin}
 [profile.dev]
 debug-assertions=true
-"#);
+"#
+    );
 
     let mut final_toml = String::default();
 

--- a/create-rust-app_cli/src/plugins/tasks.rs
+++ b/create-rust-app_cli/src/plugins/tasks.rs
@@ -2,12 +2,12 @@ use anyhow::Result;
 use indoc::indoc;
 use rust_embed::RustEmbed;
 
-use crate::{BackendDatabase, BackendFramework};
 use crate::content::cargo_toml::add_dependency;
 use crate::plugins::InstallConfig;
 use crate::plugins::Plugin;
 use crate::utils::fs;
 use crate::utils::logger::add_file_msg;
+use crate::{BackendDatabase, BackendFramework};
 
 pub struct Tasks {}
 
@@ -26,15 +26,11 @@ impl Plugin for Tasks {
         // ===============================
 
         if install_config.backend_database != BackendDatabase::Postgres {
-            return Err(anyhow::anyhow!(
-                "The tasks plugin only supports Postgres"
-            ));
+            return Err(anyhow::anyhow!("The tasks plugin only supports Postgres"));
         }
 
         if install_config.backend_framework != BackendFramework::ActixWeb {
-            return Err(anyhow::anyhow!(
-                "The tasks plugin only supports actix-web"
-            ));
+            return Err(anyhow::anyhow!("The tasks plugin only supports actix-web"));
         }
 
         // ===============================
@@ -106,12 +102,7 @@ impl Plugin for Tasks {
         // Add dependencies
         // ===============================
 
-        add_dependency(
-            &install_config.project_dir,
-            "fang",
-            r#"fang = "0.10.3""#,
-        )?;
-
+        add_dependency(&install_config.project_dir, "fang", r#"fang = "0.10.3""#)?;
 
         Ok(())
     }


### PR DESCRIPTION
Fixes #75 
Addresses #37 

example usage:

to use the default templates, but with a custom base_url,
```rust
let app_data = create_rust_app::setup()
    .with_custom_email_templates(DefaultMailTemplates::new("https://your.url.com/");
```

to use your own templates, create a struct that implements the `EmailTemplates` trait, and pass an instance of it to the `with_custom_email_templates` function as before