### PR TITLE
minor refactoring and fixes: dev module

### DIFF
--- a/create-rust-app/src/dev/controller.rs
+++ b/create-rust-app/src/dev/controller.rs
@@ -43,12 +43,11 @@ pub fn query_db(db: &Database, body: &MySqlQuery) -> Result<String, diesel::resu
 }
 
 /// /db/is-connected
-///
-/// # Panics
-/// * cannot connect to the database
 #[must_use]
 pub fn is_connected(db: &Database) -> bool {
-    let mut db = db.pool.clone().get().unwrap();
+    let Ok(mut db) = db.pool.clone().get() else {
+        return false;
+    };
     let is_connected = sql_query("SELECT 1;").execute(&mut db);
     is_connected.is_err()
 }

--- a/create-rust-app/src/dev/controller.rs
+++ b/create-rust-app/src/dev/controller.rs
@@ -1,4 +1,5 @@
 use crate::Database;
+use anyhow::{bail, Result};
 use diesel::{
     migration::{Migration, MigrationSource},
     query_dsl::RunQueryDsl,
@@ -135,9 +136,8 @@ pub fn needs_migration(db: &Database) -> bool {
 /// * cannot find the migrations directory
 /// * cannot run the migrations
 ///
-/// TODO: return a Result instead of a tuple (bool, Option<String>), this is Rust, not Go
-#[must_use]
-pub fn migrate_db(db: &Database) -> (bool, /* error message: */ Option<String>) {
+/// TODO: Propagate more of these errors instead of panicking
+pub fn migrate_db(db: &Database) -> Result<()> {
     let mut db = db.pool.clone().get().unwrap();
 
     let source = FileBasedMigrations::find_migrations_directory().unwrap();
@@ -145,15 +145,15 @@ pub fn migrate_db(db: &Database) -> (bool, /* error message: */ Option<String>) 
         MigrationHarness::has_pending_migration(&mut db, source.clone()).unwrap();
 
     if !has_pending_migrations {
-        return (true, None);
+        return Ok(());
     }
 
     let op = MigrationHarness::run_pending_migrations(&mut db, source);
     match op {
-        Ok(_) => (true, None),
+        Ok(_) => Ok(()),
         Err(err) => {
             println!("{err:#?}");
-            (false, Some(err.to_string()))
+            bail!(err)
         }
     }
 }

--- a/create-rust-app/src/dev/dev_server.rs
+++ b/create-rust-app/src/dev/dev_server.rs
@@ -300,7 +300,11 @@ async fn handle_socket(stream: WebSocket, state: Arc<AppState>) {
                                     println!("📝 Could not open file `{file_name}`");
                                 });
                             } else if t.eq_ignore_ascii_case("migrate") {
-                                let (success, error_message) = controller::migrate_db(&state3.db);
+                                let (success, error_message) =
+                                    match controller::migrate_db(&state3.db) {
+                                        Ok(_) => (true, None),
+                                        Err(e) => (false, Some(e.to_string())),
+                                    };
 
                                 state3
                                     .tx

--- a/create-rust-app/src/dev/dev_server.rs
+++ b/create-rust-app/src/dev/dev_server.rs
@@ -246,7 +246,7 @@ async fn handle_socket(stream: WebSocket, state: Arc<AppState>) {
                 }
                 DevServerEvent::CompileMessages(messages) => {
                     let mut s = state2.dev.lock().unwrap();
-                    s.compiler_messages = messages.clone();
+                    s.compiler_messages.clone_from(&messages);
                 }
                 DevServerEvent::SHUTDOWN => {
                     let mut s = state2.dev.lock().unwrap();


### PR DESCRIPTION
4 commits, details as follows:

- fix(dev): don't panic in is_connected if we couldn't get a connection to the db

it doesn't make sense for a failed connection to panic in a function that's supposed to check for a connection, this fixes that (probably) unintended behavior.

- perf: assigning the result of Clone::clone() may be inefficient

https://rust-lang.github.io/rust-clippy/master/index.html#/assigning_clones
using `clone_from` let's us avoid unnecessary allocations

- refactor(dev): migrate_db fn to return result instead of ( success, optional error_message ) tuple.

We aren't in Go, we have better error handling available so should take advantage of it

TODO: There are more cases in this function where it may be better to propagate errors rather than panicing

- refactor(dev): listen_for_signals, rename variables and refactor error handling

https://rust-lang.github.io/rust-clippy/master/index.html#/never_loop

the loop only actually runs once, so an `if let` is a much more clear expression.